### PR TITLE
Queries Bug

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -282,9 +282,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 
 	  function _addQueries(ref, queries) {
+	    var needArgs = ['limitToFirst', 'limitToLast', 'orderByChild', 'startAt', 'endAt', 'equalTo'];
 	    for (var key in queries) {
 	      if (queries.hasOwnProperty(key)) {
-	        ref = ref[key](queries[key]);
+	        if (needArgs.indexOf(key) !== 0) {
+	          ref = ref[key](queries[key]);
+	        } else {
+	          ref = ref[key]();
+	        }
 	      }
 	    }
 	    return ref;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -282,10 +282,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 
 	  function _addQueries(ref, queries) {
-	    var needArgs = ['limitToFirst', 'limitToLast', 'orderByChild', 'startAt', 'endAt', 'equalTo'];
+	    var needArgs = {
+	      limitToFirst: true,
+	      limitToLast: true,
+	      orderByChild: true,
+	      startAt: true,
+	      endAt: true,
+	      equalTo: true
+	    };
 	    for (var key in queries) {
 	      if (queries.hasOwnProperty(key)) {
-	        if (needArgs.indexOf(key) !== -1) {
+	        if (needArgs[key]) {
 	          ref = ref[key](queries[key]);
 	        } else {
 	          ref = ref[key]();

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -285,7 +285,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var needArgs = ['limitToFirst', 'limitToLast', 'orderByChild', 'startAt', 'endAt', 'equalTo'];
 	    for (var key in queries) {
 	      if (queries.hasOwnProperty(key)) {
-	        if (needArgs.indexOf(key) !== 0) {
+	        if (needArgs.indexOf(key) !== -1) {
 	          ref = ref[key](queries[key]);
 	        } else {
 	          ref = ref[key]();

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -224,9 +224,14 @@ module.exports = (function(){
   };
 
   function _addQueries(ref, queries){
+    var needArgs = ['limitToFirst', 'limitToLast', 'orderByChild', 'startAt', 'endAt', 'equalTo'];
     for(var key in queries){
       if(queries.hasOwnProperty(key)){
-        ref = ref[key](queries[key]);
+        if(needArgs.indexOf(key) !== 0) {
+          ref = ref[key](queries[key]);
+        } else {
+          ref = ref[key]();
+        }
       }
     }
     return ref;

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -227,7 +227,7 @@ module.exports = (function(){
     var needArgs = ['limitToFirst', 'limitToLast', 'orderByChild', 'startAt', 'endAt', 'equalTo'];
     for(var key in queries){
       if(queries.hasOwnProperty(key)){
-        if(needArgs.indexOf(key) !== 0) {
+        if(needArgs.indexOf(key) !== -1) {
           ref = ref[key](queries[key]);
         } else {
           ref = ref[key]();

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -224,10 +224,17 @@ module.exports = (function(){
   };
 
   function _addQueries(ref, queries){
-    var needArgs = ['limitToFirst', 'limitToLast', 'orderByChild', 'startAt', 'endAt', 'equalTo'];
+    var needArgs = {
+      limitToFirst: true,
+      limitToLast: true,
+      orderByChild: true,
+      startAt: true,
+      endAt: true,
+      equalTo: true
+    };
     for(var key in queries){
       if(queries.hasOwnProperty(key)){
-        if(needArgs.indexOf(key) !== -1) {
+        if(needArgs[key]) {
           ref = ref[key](queries[key]);
         } else {
           ref = ref[key]();


### PR DESCRIPTION
orderByKey, orderByValue, and orderByPriority were breaking because they were being called with arguments.  This removes those arguments.