### PR TITLE
Password management

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ ref.onAuth(authDataCallback);
 
 ## <a name='users'>User Management</a>
 
-re-base exposes [`createUser`](https://www.firebase.com/docs/web/api/firebase/createuser.html), [`removeUser`](https://www.firebase.com/docs/web/api/firebase/removeuser.html) and [`resetPassword`](https://www.firebase.com/docs/web/api/firebase/resetpassword.html) methods for user management.
+re-base exposes [`createUser`](https://www.firebase.com/docs/web/api/firebase/createuser.html), [`removeUser`](https://www.firebase.com/docs/web/api/firebase/removeuser.html), [`resetPassword`](https://www.firebase.com/docs/web/api/firebase/resetpassword.html) and [`changePassword`](https://www.firebase.com/docs/web/api/firebase/changepassword.html) methods for user management.
 
 ```javascript
 // Create
@@ -356,7 +356,14 @@ base.removeUser({
 
 // Reset Password
 base.resetPassword({
+  email: 'bobtony@firebase.com'
+}, errorHandler);
+
+// Change Password
+base.changePassword({
   email: 'bobtony@firebase.com',
+  oldPassword: 'correcthorsebatterystaple',
+  newPassword: 'chipsahoy'
 }, errorHandler);
 ```
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ ref.onAuth(authDataCallback);
 
 ## <a name='users'>User Management</a>
 
-re-base exposes [`createUser`](https://www.firebase.com/docs/web/api/firebase/createuser.html) and [`removeUser`](https://www.firebase.com/docs/web/api/firebase/removeuser.html) methods for user management.
+re-base exposes [`createUser`](https://www.firebase.com/docs/web/api/firebase/createuser.html), [`removeUser`](https://www.firebase.com/docs/web/api/firebase/removeuser.html) and [`resetPassword`](https://www.firebase.com/docs/web/api/firebase/resetpassword.html) methods for user management.
 
 ```javascript
 // Create
@@ -352,6 +352,11 @@ base.createUser({
 base.removeUser({
   email: 'bobtony@firebase.com',
   password: 'correcthorsebatterystaple'
+}, errorHandler);
+
+// Reset Password
+base.resetPassword({
+  email: 'bobtony@firebase.com',
 }, errorHandler);
 ```
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -388,6 +388,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	    });
 	  };
 
+	  function _resetPassword(credentials, fn) {
+	    var ref = new Firebase('' + baseUrl);
+	    return ref.resetPassword(credentials, function (error) {
+	      return fn(error);
+	    });
+	  };
+
 	  function init() {
 	    return {
 	      listenTo: function listenTo(endpoint, options) {
@@ -434,6 +441,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 	      removeUser: function removeUser(credentials, fn) {
 	        return _removeUser(credentials, fn);
+	      },
+	      resetPassword: function resetPassword(credentials, fn) {
+	        return _resetPassword(credentials, fn);
 	      }
 	    };
 	  };

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -395,6 +395,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	    });
 	  };
 
+	  function _changePassword(credentials, fn) {
+	    var ref = new Firebase('' + baseUrl);
+	    return ref.changePassword(credentials, function (error) {
+	      return fn(error);
+	    });
+	  };
+
 	  function init() {
 	    return {
 	      listenTo: function listenTo(endpoint, options) {
@@ -444,6 +451,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 	      resetPassword: function resetPassword(credentials, fn) {
 	        return _resetPassword(credentials, fn);
+	      },
+	      changePassword: function changePassword(credentials, fn) {
+	        return _changePassword(credentials, fn);
 	      }
 	    };
 	  };

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -330,6 +330,13 @@ module.exports = (function(){
     });
   };
 
+  function _resetPassword(credentials, fn){
+    var ref = new Firebase(`${baseUrl}`);
+    return ref.resetPassword(credentials, function(error) {
+      return fn(error);
+    });
+  };
+
   function init(){
     return {
       listenTo(endpoint, options){
@@ -376,6 +383,9 @@ module.exports = (function(){
       },
       removeUser(credentials,fn) {
         return _removeUser(credentials, fn);
+      },
+      resetPassword(credentials,fn) {
+        return _resetPassword(credentials, fn);
       },
     }
   };

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -337,6 +337,13 @@ module.exports = (function(){
     });
   };
 
+  function _changePassword(credentials, fn){
+    var ref = new Firebase(`${baseUrl}`);
+    return ref.changePassword(credentials, function(error) {
+      return fn(error);
+    });
+  };
+
   function init(){
     return {
       listenTo(endpoint, options){
@@ -386,6 +393,9 @@ module.exports = (function(){
       },
       resetPassword(credentials,fn) {
         return _resetPassword(credentials, fn);
+      },
+      changePassword(credentials,fn) {
+        return _changePassword(credentials, fn);
       },
     }
   };

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -969,6 +969,22 @@ describe('re-base Tests:', function(){
           done();
         });
       });
+      it('Fails to reset password for non-existant user', function(done) {
+        base.resetPassword({
+          email: dummyUsers.unknown.email,
+        }, function(error) {
+          expect(error).not.toBeNull();
+          done();
+        });
+      });
+      it('Succeeds to reset password for a user', function(done) {
+        base.resetPassword({
+          email: dummyUsers.known.email,
+        }, function(error) {
+          expect(error).toBeNull();
+          done();
+        });
+      });
     });
   });
 });

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -16,7 +16,7 @@ var dummyUsers = {
   'unknown': {email: 'unknown@thisdomainisfake.com', password: 'nonono'},
   'known': {email: 'known@thisdomainisfake.com', password: 'yeahyeahyeah'},
   'invalid': {email: 'invalid@com', password: 'correcthorsebatterystaple'},
-  'toDelete': {email: 'test@example.com', password: 'correcthorsebatterystaple'},
+  'toDelete': {email: 'test@example.com', password: 'correcthorsebatterystaple', newPassword: 'chipsahoy'},
 };
 var base;
 
@@ -951,6 +951,42 @@ describe('re-base Tests:', function(){
           done();
         });
       });
+      it('Fails to reset password for non-existant user', function(done) {
+        base.resetPassword({
+          email: dummyUsers.unknown.email,
+        }, function(error) {
+          expect(error).not.toBeNull();
+          done();
+        });
+      });
+      it('Succeeds to reset password for a user', function(done) {
+        base.resetPassword({
+          email: dummyUsers.known.email,
+        }, function(error) {
+          expect(error).toBeNull();
+          done();
+        });
+      });
+      it('Fails to change password without password', function(done) {
+        base.changePassword({
+          email: dummyUsers.known.email,
+          oldPassword: dummyUsers.known.email,
+          newPassword: '',
+        }, function(error) {
+          expect(error).not.toBeNull();
+          done();
+        });
+      });
+      it('Succeeds to change password', function(done) {
+        base.changePassword({
+          email: dummyUsers.toDelete.email,
+          oldPassword: dummyUsers.toDelete.password,
+          newPassword: dummyUsers.toDelete.newPassword,
+        }, function(error) {
+          expect(error).toBeNull();
+          done();
+        });
+      });
       it('Fails to delete a non-existant user', function(done) {
         base.removeUser({
           email: dummyUsers.unknown.email,
@@ -963,23 +999,7 @@ describe('re-base Tests:', function(){
       it('Succeeds to delete a user', function(done) {
         base.removeUser({
           email: dummyUsers.toDelete.email,
-          password: dummyUsers.toDelete.password,
-        }, function(error) {
-          expect(error).toBeNull();
-          done();
-        });
-      });
-      it('Fails to reset password for non-existant user', function(done) {
-        base.resetPassword({
-          email: dummyUsers.unknown.email,
-        }, function(error) {
-          expect(error).not.toBeNull();
-          done();
-        });
-      });
-      it('Succeeds to reset password for a user', function(done) {
-        base.resetPassword({
-          email: dummyUsers.known.email,
+          password: dummyUsers.toDelete.newPassword,
         }, function(error) {
           expect(error).toBeNull();
           done();


### PR DESCRIPTION
Adds `resetPassword` and `changePassword` methods.

Should splitting the test spec out be a thought in the future? The spec is quite long, and splitting the auth and user management out into `auth.spec.js`/`user.spec.js` and then importing them into `re-base.spec.js` might be a bit cleaner?