### PR TITLE
Added Firebase Push

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ I spent a few weeks trying to figure out the cleanest way to implement Firebase 
 - *listenTo*: Whenever your Firebase endpoint changes, it will invoke a callback passing it the new data from Firebase.
 - *fetch*: Retrieve data from Firebase without setting up any binding or listeners.
 - *post*: Add new data to Firebase.
+- *push*: Push new child data to Firebase.
 - *removeBinding*: Remove all of the Firebase listeners when your component unmounts.
 - *reset*: Removes all of the Firebase listeners and resets the singleton (for testing purposes).
 
@@ -43,7 +44,7 @@ $ npm install re-base
       - The absolute, HTTPS URL of your Firebase project
 
 ##### Return Value
-  An object with syncState, bindToState, listenTo, fetch, post, removeBinding, and reset methods.
+  An object with syncState, bindToState, listenTo, fetch, post, push, removeBinding, and reset methods.
 
 ##### Example
 
@@ -228,6 +229,39 @@ getSales(){
 addUser(){
   base.post('users/${userId}', {
     data: {name: 'Tyler McGinnis', age: 25},
+    then(){
+      Router.transitionTo('dashboard');
+    }
+  });
+}
+```
+
+<br />
+
+## push(endpoint, options)
+
+#### Purpose
+  Allows you to add data to a Firebase endpoint. *Adds data to a child of the endpoint with a new Firebase push key*
+
+#### Arguments
+  1. endpoint
+    - type: string
+    - The relative Firebase endpoint that you'd like to push the new data to
+  2. options
+    - type: object
+    - properties:
+      - data: (any - required) The data you're wanting to persist to Firebase
+      - then: (function - optional) A callback that will get invoked once the new data has been saved to Firebase
+
+#### Return Value
+  No return value
+
+#### Example
+
+```javascript
+addBear(){
+  base.push('bears', {
+    data: {name: 'George', type: 'Grizzly'},
     then(){
       Router.transitionTo('dashboard');
     }

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -286,6 +286,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  };
 
+	  function _push(endpoint, options) {
+	    _validateEndpoint(endpoint);
+	    optionValidators.data(options);
+	    var ref = new Firebase(baseUrl + '/' + endpoint);
+	    if (options.then) {
+	      ref.push(options.data, options.then);
+	    } else {
+	      ref.push(options.data);
+	    }
+	  };
+
 	  function _addQueries(ref, queries) {
 	    var needArgs = {
 	      limitToFirst: true,
@@ -423,6 +434,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 	      post: function post(endpoint, options) {
 	        _post(endpoint, options);
+	      },
+	      push: function push(endpoint, options) {
+	        _push(endpoint, options);
 	      },
 	      removeBinding: function removeBinding(endpoint) {
 	        _removeBinding(endpoint, true);

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -228,6 +228,17 @@ module.exports = (function(){
     }
   };
 
+  function _push(endpoint, options){
+    _validateEndpoint(endpoint);
+    optionValidators.data(options);
+    var ref = new Firebase(`${baseUrl}/${endpoint}`);
+    if(options.then){
+      ref.push(options.data, options.then);
+    } else {
+      ref.push(options.data);
+    }
+  };
+
   function _addQueries(ref, queries){
     var needArgs = {
       limitToFirst: true,
@@ -365,6 +376,9 @@ module.exports = (function(){
       },
       post(endpoint, options){
         _post(endpoint, options);
+      },
+      push(endpoint, options){
+        _push(endpoint, options);
       },
       removeBinding(endpoint){
         _removeBinding(endpoint, true);

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -102,6 +102,47 @@ describe('re-base Tests:', function(){
     });
   });
 
+
+  describe('push()', function(){
+    it('push() throws an error given a invalid endpoint', function(){
+      invalidEndpoints.forEach((endpoint) => {
+        try {
+          base.push(endpoint, {
+            data: dummyObjData
+          })
+        } catch(err) {
+          expect(err.code).toEqual('INVALID_ENDPOINT');
+        }
+      });
+    });
+
+    it('push() throws an error given an invalid options object', function(){
+      var invalidOptions = [[], {}, {then: function(){}}, {data: undefined}];
+      invalidOptions.forEach((option) => {
+        try {
+          base.push(testEndpoint, option);
+        } catch(err) {
+          expect(err.code).toEqual('INVALID_OPTIONS');
+        }
+      });
+    });
+
+    it('push() updates Firebase correctly', function(done){
+      base.push(testEndpoint, {
+        data: dummyObjData,
+        then(){
+          ref.child(testEndpoint).once('value', (snapshot) => {
+            var keyedData = snapshot.val();
+            var data = keyedData[Object.keys(keyedData)[0]];
+
+            expect(data).toEqual(dummyObjData);
+            done();
+          });
+        }
+      })
+    });
+  });
+
   describe('fetch()', function(){
     it('fetch() throws an error given a invalid endpoint', function(done){
       invalidEndpoints.forEach((endpoint) => {


### PR DESCRIPTION
Can now use Firebase .push() in addition to .set() for writing data to child locations and Firebase queues.

Updated README and Tests