### PR TITLE
Update syncState to support multiple keys at a time

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -250,12 +250,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    optionValidators.context(options);
 	    optionValidators.state(options);
 	    options.queries && optionValidators.query(options);
-	    if (_sync.called !== true) {
-	      _sync.reactSetState = options.context.setState;
-	      _sync.called = true;
-	    } else {
-	      options.context.setState = _sync.reactSetState;
-	    }
+
 	    options.reactSetState = options.context.setState;
 	    options.then && (options.then.called = false);
 	    var ref = new Firebase(baseUrl + '/' + endpoint);
@@ -266,10 +261,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (data.hasOwnProperty(key)) {
 	          if (key === options.state) {
 	            _updateSyncState.call(this, ref, data[key], key);
-	          } else {
-	            options.reactSetState.call(options.context, data, cb);
 	          }
 	        }
+
+	        // Call all previous "setState"s recursively to make sure they all update
+	        options.reactSetState.call(options.context, data, cb);
 	      }
 	    };
 	    return _returnRef(endpoint, 'syncState');
@@ -350,6 +346,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  function _authWithPassword(credentials, fn) {
 	    var ref = new Firebase('' + baseUrl);
 	    return ref.authWithPassword(credentials, function (error, authData) {
+	      return fn(error, authData);
+	    });
+	  }
+
+	  function _authWithCustomToken(token, fn) {
+	    var ref = new Firebase('' + baseUrl);
+	    return ref.authWithCustomToken(token, function (error, authData) {
 	      return fn(error, authData);
 	    });
 	  }
@@ -446,6 +449,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 	      authWithPassword: function authWithPassword(credentials, fn) {
 	        return _authWithPassword(credentials, fn);
+	      },
+	      authWithCustomToken: function authWithCustomToken(token, fn) {
+	        return _authWithCustomToken(token, fn);
 	      },
 	      authWithOAuthPopup: function authWithOAuthPopup(provider, fn, settings) {
 	        return _authWithOAuthPopup(provider, fn, settings);

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -205,7 +205,7 @@ module.exports = (function(){
             _updateSyncState.call(this, ref, data[key], key)
           }
         }
-        
+
         // Call all previous "setState"s recursively to make sure they all update
         options.reactSetState.call(options.context, data, cb);
      }

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -193,23 +193,45 @@ module.exports = (function(){
     optionValidators.state(options);
     options.queries && optionValidators.query(options);
 
+    if(_sync.called !== true){
+      _sync.reactSetState = options.context.setState;
+      _sync.called = true;
+    } else {
+      options.context.setState = _sync.reactSetState;
+    }
     options.reactSetState = options.context.setState;
     options.then && (options.then.called = false);
+
     var ref = new Firebase(`${baseUrl}/${endpoint}`);
     _firebaseRefsMixin(endpoint, 'syncState', ref);
     _addListener(endpoint, 'syncState', options, ref);
-    options.context.setState = function (data, cb) {
-      for (var key in data) {
-        if(data.hasOwnProperty(key)){
-          if (key === options.state) {
-            _updateSyncState.call(this, ref, data[key], key)
+
+    if (!_sync.setStates) {
+        _sync.setStates = [];
+    }
+
+    // Record all of our methods to handle the keys that need syncing
+    _sync.setStates.push(
+      function (data, cb) {
+        for (var key in data) {
+          if(data.hasOwnProperty(key)){
+            if (key === options.state) {
+              _updateSyncState.call(this, ref, data[key], key);
+            } else {
+              options.reactSetState.call(options.context, data, cb);
+            }
           }
         }
+      }
+    );
 
-        // Call all previous "setState"s recursively to make sure they all update
-        options.reactSetState.call(options.context, data, cb);
-     }
-    };
+    // Make sure the replaced method calls all of them
+    options.context.setState = function(data, cb) {
+        _sync.setStates.forEach(f => {
+            f(data, cb);
+        });
+    }
+
     return _returnRef(endpoint, 'syncState');
   };
 

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -192,12 +192,7 @@ module.exports = (function(){
     optionValidators.context(options);
     optionValidators.state(options);
     options.queries && optionValidators.query(options);
-    if(_sync.called !== true){
-      _sync.reactSetState = options.context.setState;
-      _sync.called = true;
-    } else {
-      options.context.setState = _sync.reactSetState;
-    }
+
     options.reactSetState = options.context.setState;
     options.then && (options.then.called = false);
     var ref = new Firebase(`${baseUrl}/${endpoint}`);
@@ -208,10 +203,11 @@ module.exports = (function(){
         if(data.hasOwnProperty(key)){
           if (key === options.state) {
             _updateSyncState.call(this, ref, data[key], key)
-         } else {
-            options.reactSetState.call(options.context, data, cb);
-         }
+          }
         }
+        
+        // Call all previous "setState"s recursively to make sure they all update
+        options.reactSetState.call(options.context, data, cb);
      }
     };
     return _returnRef(endpoint, 'syncState');

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -626,6 +626,88 @@ describe('re-base Tests:', function(){
     });
 
     describe('Async tests', function(){
+
+      it('syncState() supports syncing of multiple keys', function(done) {
+        class TestComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              one: 0,
+              two: 0,
+              three: 0
+            }
+          }
+
+          componentWillMount() {
+            this.refOne = base.syncState('one', {
+              context: this,
+              state: 'one'
+            });
+
+            this.refTwo = base.syncState('two', {
+              context: this,
+              state: 'two'
+            });
+
+            this.refThree = base.syncState('three', {
+              context: this,
+              state: 'three'
+            });
+
+            this.counter = 0;
+
+            base.listenTo('one', {
+              context: this,
+              then(data) {
+                expect(data).toEqual(1);
+                this.counter++;
+              }
+            });
+
+            base.listenTo('two', {
+              context: this,
+              then(data) {
+                expect(data).toEqual(2);
+                this.counter++;
+              }
+            });
+
+            base.listenTo('three', {
+              context: this,
+              then(data) {
+                expect(data).toEqual(3);
+                this.counter++;
+              }
+            });
+          }
+
+          checkDone() {
+            if (this.counter == 3) {
+              done();
+            }
+          }
+
+          componentDidUpdate() {
+            this.checkDone();
+          }
+
+          componentDidMount() {
+            this.setState({ one: 1 });
+            this.setState({ two: 2 });
+            this.setState({ three: 3 });
+          }
+
+          render(){
+            return (
+              <div>
+                No Data
+              </div>
+            )
+          }
+        }
+        React.render(<TestComponent />, document.body);
+      });
+
       it('syncState() returns an empty object when there is no Firebase data and asArray is false', function(done){
         class TestComponent extends React.Component{
           constructor(props){

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -656,7 +656,7 @@ describe('re-base Tests:', function(){
 
             this.counter = 0;
 
-            base.listenTo('one', {
+            this.listenerOne = base.listenTo('one', {
               context: this,
               then(data) {
                 expect(data).toEqual(1);
@@ -664,7 +664,7 @@ describe('re-base Tests:', function(){
               }
             });
 
-            base.listenTo('two', {
+            this.listenerTwo = base.listenTo('two', {
               context: this,
               then(data) {
                 expect(data).toEqual(2);
@@ -672,7 +672,7 @@ describe('re-base Tests:', function(){
               }
             });
 
-            base.listenTo('three', {
+            this.listenerThree = base.listenTo('three', {
               context: this,
               then(data) {
                 expect(data).toEqual(3);
@@ -695,6 +695,10 @@ describe('re-base Tests:', function(){
             this.setState({ one: 1 });
             this.setState({ two: 2 });
             this.setState({ three: 3 });
+          }
+
+          componentWillUnmount() {
+            base.reset();
           }
 
           render(){


### PR DESCRIPTION
This is to address: https://github.com/tylermcginnis/re-base/issues/40

Previously, when setState was replaced it overwrote all the previously bound "setState"s so only the last syncState actually wrote to Firebase. My change chains all the setState calls together and fixes this.

I am a little unclear on what the `_sync.called` if statement was intended to achieve, but removing it causes the library to function as expected (I may have missed an edge case though). I would appreciate someone taking a look and making sure I didn't completely break something in the process? Or at least explaining what the code I removed was for?

Cheers!