### PR TITLE
Add authWithCustomToken documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The binding above will sort the `users` endpoint by iq, retrieve the last three 
 
 ## <a name='auth'>Authentication</a>
 
-re-base exposes [Firebase's web client](https://www.firebase.com/docs/web/guide/user-auth.html#section-login) `authWithPassword`, `authWithOAuthPopup`, `authWithOAuthRedirect`, `authWithOAuthToken` methods to allow user authentication. `getAuth` is also exposed to access the current authentication state.
+re-base exposes [Firebase's web client](https://www.firebase.com/docs/web/guide/user-auth.html#section-login) `authWithPassword`, `authWithCustomToken`, `authWithOAuthPopup`, `authWithOAuthRedirect`, `authWithOAuthToken` methods to allow user authentication. `getAuth` is also exposed to access the current authentication state.
 
 ```javascript
 // Simple email authentication
@@ -343,6 +343,9 @@ base.authWithPassword({
   email    : 'bobtony@firebase.com',
   password : 'correcthorsebatterystaple'
 }, authHandler);
+
+// Authentication via a custom authentication token
+base.authWithCustomToken(token, authHandler);
 
 // Authentication via OAuth providers ("facebook", "github", "google", or "twitter")
 base.authWithOAuthPopup("<provider>", authHandler);


### PR DESCRIPTION
#62 added the `authWithCustomToken` method, but it wasn't documented. I added it to the README.