### PR TITLE
Allow multiple callbacks for a single method on the same endpoint

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -174,7 +174,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 
 	  function _returnRef(endpoint, method) {
-	    return { endpoint: endpoint, method: method };
+	    var id = Date.now();
+	    return { endpoint: endpoint, method: method, id: id };
 	  };
 
 	  function _fetch(endpoint, options) {
@@ -193,17 +194,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	  function _firebaseRefsMixin(endpoint, invoker, ref) {
 	    if (!_isObject(firebaseRefs[endpoint])) {
 	      firebaseRefs[endpoint] = _defineProperty({}, invoker, ref.ref());
-	      firebaseListeners[endpoint] = {};
+	      if (!firebaseListeners[endpoint]) {
+	        firebaseListeners[endpoint] = {};
+	      }
+	      if (!firebaseListeners[endpoint][invoker]) {
+	        firebaseListeners[endpoint][invoker] = {};
+	      }
 	    } else if (!firebaseRefs[endpoint][invoker]) {
 	      firebaseRefs[endpoint][invoker] = ref.ref();
-	    } else {
-	      _throwError('Endpoint (' + endpoint + ') already has listener ' + invoker, "INVALID_ENDPOINT");
 	    }
 	  };
 
-	  function _addListener(endpoint, invoker, options, ref) {
+	  function _addListener(endpoint, invoker, options, ref, id) {
 	    ref = _addQueries(ref, options.queries);
-	    firebaseListeners[endpoint][invoker] = ref.on('value', function (snapshot) {
+	    firebaseListeners[endpoint][invoker][id] = ref.on('value', function (snapshot) {
 	      var data = snapshot.val();
 	      data = data === null ? options.asArray === true ? [] : {} : data;
 	      if (invoker === 'listenTo') {
@@ -231,8 +235,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    options.queries && optionValidators.query(options);
 	    var ref = new Firebase(baseUrl + '/' + endpoint);
 	    _firebaseRefsMixin(endpoint, invoker, ref);
-	    _addListener(endpoint, invoker, options, ref);
-	    return _returnRef(endpoint, invoker);
+	    var returnRef = _returnRef(endpoint, invoker);
+	    _addListener(endpoint, invoker, options, ref, returnRef.id);
+	    return returnRef;
 	  };
 
 	  function _updateSyncState(ref, data, key) {
@@ -260,7 +265,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    options.then && (options.then.called = false);
 	    var ref = new Firebase(baseUrl + '/' + endpoint);
 	    _firebaseRefsMixin(endpoint, 'syncState', ref);
-	    _addListener(endpoint, 'syncState', options, ref);
+	    var returnRef = _returnRef(endpoint, 'syncState');
+	    _addListener(endpoint, 'syncState', options, ref, returnRef.id);
 	    options.context.setState = function (data, cb) {
 	      for (var key in data) {
 	        if (data.hasOwnProperty(key)) {
@@ -272,7 +278,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	      }
 	    };
-	    return _returnRef(endpoint, 'syncState');
+	    return returnRef;
 	  };
 
 	  function _post(endpoint, options) {
@@ -326,9 +332,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var errorMsg = 'Unexpected value for endpoint. ' + refObj.endpoint + ' was either never bound or has already been unbound.';
 	      _throwError(errorMsg, "UNBOUND_ENDPOINT_VARIABLE");
 	    }
-	    firebaseRefs[refObj.endpoint][refObj.method].off('value', firebaseListeners[refObj.endpoint][refObj.method]);
-	    delete firebaseRefs[refObj.endpoint][refObj.method];
-	    delete firebaseListeners[refObj.endpoint][refObj.method];
+	    firebaseRefs[refObj.endpoint][refObj.method].off('value', firebaseListeners[refObj.endpoint][refObj.method][refObj.id]);
+	    delete firebaseListeners[refObj.endpoint][refObj.method][refObj.id];
+	    if (!Object.keys(firebaseListeners[refObj.endpoint][refObj.method]).length) {
+	      delete firebaseRefs[refObj.endpoint][refObj.method];
+	    }
 	  };
 
 	  function _reset() {
@@ -338,7 +346,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (firebaseRefs.hasOwnProperty(key)) {
 	        for (var prop in firebaseRefs[key]) {
 	          if (firebaseRefs[key].hasOwnProperty(prop)) {
-	            firebaseRefs[key][prop].off('value', firebaseListeners[key][prop]);
+	            for (var callback_id in firebaseListeners[key][prop]) {
+	              if (firebaseListeners[key][prop].hasOwnProperty(callback_id)) {
+	                firebaseRefs[key][prop].off('value', firebaseListeners[key][prop][callback_id]);
+	              }
+	            }
 	            delete firebaseRefs[key][prop];
 	            delete firebaseListeners[key][prop];
 	          }

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -342,21 +342,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	  function _reset() {
 	    baseUrl = '';
 	    rebase = undefined;
-	    for (var key in firebaseRefs) {
-	      if (firebaseRefs.hasOwnProperty(key)) {
-	        for (var prop in firebaseRefs[key]) {
-	          if (firebaseRefs[key].hasOwnProperty(prop)) {
-	            for (var callback_id in firebaseListeners[key][prop]) {
-	              if (firebaseListeners[key][prop].hasOwnProperty(callback_id)) {
-	                firebaseRefs[key][prop].off('value', firebaseListeners[key][prop][callback_id]);
-	              }
-	            }
-	            delete firebaseRefs[key][prop];
-	            delete firebaseListeners[key][prop];
-	          }
-	        }
-	      }
-	    }
+	    Object.getOwnPropertyNames(firebaseRefs).forEach(function (key) {
+	      Object.getOwnPropertyNames(firebaseRefs[key]).forEach(function (prop) {
+	        Object.getOwnPropertyNames(firebaseListeners[key][prop]).forEach(function (callback_id) {
+	          firebaseRefs[key][prop].off('value', firebaseListeners[key][prop][callback_id]);
+	        });
+	        delete firebaseRefs[key][prop];
+	        delete firebaseListeners[key][prop];
+	      });
+	    });
 	    firebaseRefs = {};
 	    firebaseListeners = {};
 	  };

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -284,21 +284,15 @@ module.exports = (function(){
   function _reset(){
     baseUrl = '';
     rebase = undefined;
-    for(var key in firebaseRefs){
-      if(firebaseRefs.hasOwnProperty(key)){
-        for(var prop in firebaseRefs[key]){
-          if(firebaseRefs[key].hasOwnProperty(prop)){
-            for (var callback_id in firebaseListeners[key][prop]) {
-              if (firebaseListeners[key][prop].hasOwnProperty(callback_id)) {
-                firebaseRefs[key][prop].off('value', firebaseListeners[key][prop][callback_id]);
-              }
-            }
-            delete firebaseRefs[key][prop];
-            delete firebaseListeners[key][prop];
-          }
-        }
-      }
-    }
+    Object.getOwnPropertyNames(firebaseRefs).forEach(function (key) {
+      Object.getOwnPropertyNames(firebaseRefs[key]).forEach(function (prop) {
+        Object.getOwnPropertyNames(firebaseListeners[key][prop]).forEach(function (callback_id) {
+            firebaseRefs[key][prop].off('value', firebaseListeners[key][prop][callback_id]);
+        })
+        delete firebaseRefs[key][prop];
+        delete firebaseListeners[key][prop];
+      })
+    })
     firebaseRefs = {};
     firebaseListeners = {};
   };
@@ -315,7 +309,7 @@ module.exports = (function(){
     return ref.authWithCustomToken(token, function(error, authData){
       return fn(error, authData);
     });
-  }
+ }
 
   function _authWithOAuthPopup(provider, fn, settings){
     settings = settings || {};

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -297,7 +297,7 @@ describe('re-base Tests:', function(){
 
         }
       });
-      expect(ref).toEqual({ endpoint: testEndpoint, method: 'listenTo' });
+      expect(ref).toEqual({ endpoint: testEndpoint, method: 'listenTo', id: ref.id });
     })
 
     it('listenTo() throws an error given a invalid endpoint', function(done){


### PR DESCRIPTION
I ran into an issue while developing a fairly simple web app where I needed to have two components listen to the same endpoint in my firebase db. My usertoolbar component (a header that shows username and avatar etc) subscribes to my 'profiles/:id' endpoint via bindToState, and I need listen to this endpoint via bindToState in a few other places, specifically form components that can only be used by an authenticated user. These form components also need to know about the user's profile info.