### PR TITLE
update() method for updating existing data on endpoint

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -286,6 +286,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  };
 
+	  function _update(endpoint, options) {
+	    _validateEndpoint(endpoint);
+	    optionValidators.data(options);
+	    var ref = new Firebase(baseUrl + '/' + endpoint);
+	    if (options.then) {
+	      ref.update(options.data, options.then);
+	    } else {
+	      ref.update(options.data);
+	    }
+	  };
+
 	  function _push(endpoint, options) {
 	    _validateEndpoint(endpoint);
 	    optionValidators.data(options);
@@ -451,6 +462,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      },
 	      post: function post(endpoint, options) {
 	        _post(endpoint, options);
+	      },
+	      update: function update(endpoint, options) {
+	        _update(endpoint, options);
 	      },
 	      push: function push(endpoint, options) {
 	        return _push(endpoint, options);

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -228,6 +228,17 @@ module.exports = (function(){
     }
   };
 
+  function _update(endpoint, options){
+    _validateEndpoint(endpoint);
+    optionValidators.data(options);
+    var ref = new Firebase(`${baseUrl}/${endpoint}`);
+    if(options.then){
+      ref.update(options.data, options.then);
+    } else {
+      ref.update(options.data);
+    }
+  };
+
   function _push(endpoint, options){
     _validateEndpoint(endpoint);
     optionValidators.data(options);
@@ -393,6 +404,9 @@ module.exports = (function(){
       },
       post(endpoint, options){
         _post(endpoint, options);
+      },
+      update(endpoint, options){
+        _update(endpoint, options);
       },
       push(endpoint, options){
         return _push(endpoint, options);

--- a/tests/specs/re-base.spec.js
+++ b/tests/specs/re-base.spec.js
@@ -102,6 +102,49 @@ describe('re-base Tests:', function(){
     });
   });
 
+  describe('update()', function(){
+    it('update() throws an error given a invalid endpoint', function(){
+      invalidEndpoints.forEach((endpoint) => {
+        try {
+          base.update(endpoint, {
+            data: dummyObjData
+          })
+        } catch(err) {
+          expect(err.code).toEqual('INVALID_ENDPOINT');
+        }
+      });
+    });
+
+    it('update() throws an error given an invalid options object', function(){
+      var invalidOptions = [[], {}, {then: function(){}}, {data: undefined}];
+      invalidOptions.forEach((option) => {
+        try {
+          base.update(testEndpoint, option);
+        } catch(err) {
+          expect(err.code).toEqual('INVALID_OPTIONS');
+        }
+      });
+    });
+
+    it('update() updates Firebase correctly without deleting pre existing properties', function(done){
+      var prePopData = {name: 'Chris Buusmann', age: 29, human: true};
+      base.post(testEndpoint, {
+        data: prePopData,
+        then(){
+          base.update(testEndpoint, {
+            data: dummyObjData,
+            then(){
+              ref.child(testEndpoint).once('value', (snapshot) => {
+                var data = snapshot.val();
+                expect(data.human).toEqual(true);
+                done();
+              });
+            }
+          })
+        }
+      })
+    });
+  });
 
   describe('push()', function(){
     it('push() throws an error given a invalid endpoint', function(){


### PR DESCRIPTION
**Problem**
At the moment it is not possible to [update](https://www.firebase.com/docs/web/api/firebase/update.html) an endpoint outside of a `syncState()` call. Since `syncState()` does only support one synced endpoint at any time it lead me to some confusion having a `ref` and a `base` around [#40](https://github.com/tylermcginnis/re-base/issues/40).

**Example**
A delivery service has a user, where a user can also be a driver. A driver has deliveries.
If I want to fetch and or manipulate driver data and update some params, then I am forced to call `ref.update(newDriverData)` as Rebase doesn't support the `update()` call outside of a `synced state`.

**Solution**
I've added an `update()` method which will call `ref.update()` as opposed to `set()` behind the scenes. This is a tentative solution which works around the fact that we can't sync the state of more than one endpoint at the moment. To me it seems a bit cleaner to implement this method in Rebase rather than having to deal with two different ways of sending data to Firebase, although I do appreciate it might add a bit of confusion to the API.

First PR ever, so please let me know if I can do anything to improve the request.