### PR TITLE
WIP: update firebase query documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ componentWillUnmount(){
 
 ## <a name='queries'>Queries</a>
 
-Use the query option to utilize the [Firebase Query](https://www.firebase.com/docs/web/guide/retrieving-data.html#section-queries) API.  For a list of available queries and how they work, see the Firebase docs.
+Use the query option to utilize the [Firebase Query](https://firebase.google.com/docs/reference/js/firebase.database.Query) API.  For a list of available queries and how they work, see the Firebase docs.
 
 Queries are accepted in the `options` object of each read method (`syncState`, `bindToState`, `listenTo`, and `fetch`).  The object should have one or more keys of the type of query you wish to run, with the value being the value for the query.  For example:
 


### PR DESCRIPTION
The link for query documentation seems to point to the deprecated documentation. I've updated the link to point to the new site.

I ran the test as specified in the _contributing_ section. Not all test passed even before I made any change. Please do guide me know if I am missing anything.

I am only getting started contributing to open source and this would be one of the first. So if I have not done things right, please understand. Your guidance would be much appreciated. Thanks 