### PR TITLE
syncState: overwrite value at location instead of merge

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -403,18 +403,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var _updateSyncState = function _updateSyncState(ref, data) {
-	  if (_isObject(data)) {
-	    for (var prop in data) {
-	      //allow timestamps to be set
-	      if (prop !== '.sv') {
-	        _updateSyncState(ref.child(prop), data[prop]);
-	      } else {
-	        ref.set(data);
-	      }
-	    }
-	  } else {
-	    ref.set(data);
-	  }
+	  ref.set(data);
 	};
 
 	var _addListener = function _addListener(id, invoker, options, ref, listeners) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -83,18 +83,7 @@ const _firebaseRefsMixin = function (id, ref, refs){
 };
 
 const _updateSyncState = function (ref, data){
-  if(_isObject(data)) {
-    for(var prop in data){
-      //allow timestamps to be set
-        if(prop !== '.sv'){
-            _updateSyncState(ref.child(prop), data[prop]);
-        } else {
-          ref.set(data);
-        }
-      }
-  } else {
-    ref.set(data);
-  }
+  ref.set(data);
 };
 
 const _addListener = function _addListener(id, invoker, options, ref, listeners){

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -40,7 +40,7 @@ describe('syncState()', function(){
     ]).then(done);
   });
 
-  it('syncState() throws an error given a invalid endpoint', function(done){
+  it('syncState() throws an error given a invalid endpoint', function(){
     invalidEndpoints.forEach((endpoint) => {
       try {
         base.syncState(endpoint, {
@@ -50,7 +50,6 @@ describe('syncState()', function(){
         })
       } catch(err) {
         expect(err.code).toEqual('INVALID_ENDPOINT');
-        done();
       }
     });
   });
@@ -279,16 +278,20 @@ describe('syncState()', function(){
         }
         componentDidMount(){
           this.setState({
-            user: {name: 'Tyler'}
+            user: {name: 'Tyler', updated: true}
           });
         }
         componentDidUpdate(){
-          ref.child(`${testEndpoint}/userData`).once('value', (snapshot) => {
+          this.check = ref.child(`${testEndpoint}/userData`).on('value', (snapshot) => {
             var data = snapshot.val();
-            expect(data).toEqual(this.state.user);
-            expect(data).toEqual({name: 'Tyler'});
-            ReactDOM.unmountComponentAtNode(document.body);
-            done();
+            if(data !== null && data.updated === true){
+              expect(data).toEqual(this.state.user);
+              expect(data).toEqual({name: 'Tyler', updated: true});
+              ReactDOM.unmountComponentAtNode(document.body);
+              ref.child(`${testEndpoint}/userData`).off('value', this.check);
+              delete this.check;
+              done();
+            }
           });
         };
         render(){
@@ -428,6 +431,62 @@ describe('syncState()', function(){
         }
       }
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncState() correctly removes deleted child keys from nested object data structure', function(done){
+      var initialData = {
+          name: 'Tyler',
+          age: 25,
+          friends: ['Joey', 'Mikenzi', 'Jacob'],
+          foo: {
+            bar: 'bar',
+            foobar: 'barfoo'
+          }
+      };
+
+        class TestComponent extends React.Component{
+          constructor(props){
+            super(props);
+          }
+          componentWillMount(){
+          }
+          componentDidMount(){
+            //populate initial data
+            ref.child(`${testEndpoint}/userData`).set(initialData).then(() => {
+              this.ref = base.syncState(`${testEndpoint}/userData`, {
+                context: this,
+                state: 'user',
+              });
+              this.setState({
+                  user: {
+                    name: 'Tyler',
+                    age: 26,
+                    friends: ['Joey', 'Mikenzi', 'Jacob'],
+                    foo: {
+                      bar: 'bar'
+                    },
+                    updated: true
+                  }
+              });
+            });
+          }
+          componentDidUpdate(){
+              if(this.state.user.updated === true){
+                expect(this.state.user.foo.foobar).toBeUndefined();
+                expect(this.state.user.age).toEqual(26);
+                ReactDOM.unmountComponentAtNode(document.body);
+                done();
+              }
+          }
+          render(){
+            return (
+              <div>
+                No Data
+              </div>
+            )
+          }
+        }
+        ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
     it('syncState() correctly retrieves Firebase data when given query options', function(done){


### PR DESCRIPTION
This PR resolves #154 . syncState is currently merging the state of the component with the value at the location in firebase its syncing to instead of overwriting it. As a result the only way to remove a child key is to set its value to `null`. Setting the state of the component to a new object that does not contain the child key has no effect on the component state. It looks like this was introduced solving #9 and this PR would revert that. It would be a breaking change I think as existing calls to `setState` that are only updating nested keys would now delete any other child keys that exist at the location.

I am a little torn on this. My understanding is that `setState` by itself, in a plain React component, will not merge nested keys without something like immutability helpers. For that reason, I prefer this PR's approach because I think it more closely matches the expected behavior when calling `setState` . However, because using `syncState` technically overrides the components `setState` for changes to the state property its syncing to, saying that you can expect the **exact** same behavior when calling the `setState` that re-base provides with `syncState` might not be accurate anyways.
