### PR TITLE
Ensure synced keys only run through their respective update function

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -689,22 +689,30 @@ return /******/ (function(modules) { // webpackBootstrap
 	  (0, _utils._addSync)(options.context, sync, state.syncs);
 
 	  options.context.setState = function (data, cb) {
-	    var _this = this;
-
 	    var syncsToCall = state.syncs.get(this);
 	    //if sync does not exist, call original Component.setState
 	    if (!syncsToCall || syncsToCall.length === 0) {
 	      return _sync.reactSetState.call(this, data, cb);
 	    }
-	    syncsToCall.forEach(function (sync) {
-	      for (var key in data) {
-	        if (data.hasOwnProperty(key)) {
-	          if (key === sync.stateKey) {
-	            sync.updateFirebase(data[key]);
-	          } else {
-	            _sync.reactSetState.call(_this, data, cb);
-	          }
-	        }
+	    var syncedKeys = syncsToCall.map(function (sync) {
+	      return {
+	        key: sync.stateKey,
+	        update: sync.updateFirebase
+	      };
+	    });
+	    syncedKeys.forEach(function (syncedKey) {
+	      if (data.hasOwnProperty(syncedKey.key)) {
+	        syncedKey.update(data[syncedKey.key]);
+	      }
+	    });
+	    var allKeys = Object.keys(data);
+	    allKeys.forEach(function (key) {
+	      if (!syncedKeys.find(function (syncedKey) {
+	        return syncedKey.key === key;
+	      })) {
+	        var update = {};
+	        update[key] = data[key];
+	        _sync.reactSetState.call(options.context, update, cb);
 	      }
 	    });
 	  };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-base",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "A Relay inspired library for building React.js + Firebase applications.",
   "main": "index.js",
   "repository": {

--- a/src/lib/database/sync.js
+++ b/src/lib/database/sync.js
@@ -41,15 +41,23 @@ export default function _sync(endpoint, options, state){
     if(!syncsToCall || syncsToCall.length === 0){
       return _sync.reactSetState.call(this, data, cb);
     }
-    syncsToCall.forEach(sync => {
-      for (var key in data) {
-        if (data.hasOwnProperty(key)){
-          if (key === sync.stateKey) {
-            sync.updateFirebase(data[key]);
-          } else {
-            _sync.reactSetState.call(this, data, cb);
-          }
-        }
+    var syncedKeys = syncsToCall.map(sync => {
+      return {
+        key : sync.stateKey,
+        update: sync.updateFirebase
+      }
+    });
+    syncedKeys.forEach( syncedKey => {
+      if(data.hasOwnProperty(syncedKey.key)){
+        syncedKey.update(data[syncedKey.key]);
+      }
+    });
+    var allKeys = Object.keys(data);
+    allKeys.forEach(key => {
+      if(!syncedKeys.find(syncedKey => syncedKey.key === key)){
+        var update = {};
+        update[key] = data[key];
+        _sync.reactSetState.call(options.context, update, cb);
       }
     });
   }

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -111,6 +111,8 @@ describe('syncState()', function(){
           this.listener1 = ref.child(`${testEndpoint}/one`).on('value', snapshot => {
             var data = snapshot.val();
             if(data){
+              expect(data).toEqual(1);
+              expect(this.state.one).toEqual(1);
               counter++;
               this.checkDone();
             }
@@ -120,6 +122,7 @@ describe('syncState()', function(){
             var data = snapshot.val();
             if(data){
               expect(data).toEqual(2);
+              expect(this.state.two).toEqual(2);
               counter++;
               this.checkDone();
             }
@@ -129,6 +132,7 @@ describe('syncState()', function(){
             var data = snapshot.val();
             if(data){
               expect(data).toEqual(3);
+              expect(this.state.three).toEqual(3);
               counter++;
               this.checkDone();
             }
@@ -141,6 +145,59 @@ describe('syncState()', function(){
             ReactDOM.unmountComponentAtNode(document.getElementById('mount'));
             done();
           }
+        }
+
+        componentDidUpdate() {
+          this.checkDone();
+        }
+
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncState() should only run synced keys through their respective update function', function(done) {
+      var counter = 0;
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            one: 0,
+            two: 0,
+            three: 0
+          }
+        }
+
+        componentDidMount() {
+          this.refOne = base.syncState(`${testEndpoint}/one`, {
+            context: this,
+            state: 'one',
+            then(){
+            }
+          });
+
+          this.refTwo = base.syncState(`${testEndpoint}/two`, {
+            context: this,
+            state: 'two',
+            then(){
+            }
+          });
+          this.setState({ one: 1, two: { key1: null, key2: 'value'}, three: { key1: null, key2: 'value'}});
+          setTimeout(() => {
+            this.checkDone();
+          }, 500);
+        }
+        checkDone() {
+            expect(this.state.one).toEqual(1);
+            expect(this.state.two.key1).toBeUndefined();
+            expect(this.state.three.key1).toBeNull();
+            done();
         }
 
         componentDidUpdate() {
@@ -308,6 +365,7 @@ describe('syncState()', function(){
           super(props);
           this.state = {
             loading: true,
+            user: {}
           }
         }
         componentDidMount(){


### PR DESCRIPTION
Fix for #154 . Makes sure that keys that are synced run changes through their respective update function first which allows for keys to be deleted by setting value to `null`