### PR TITLE
Add onFailure callback to syncState, listenTo, bindToState

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ myApp.delete(() => {
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
       - then: (function - optional) The callback function that will be invoked when the initial listener is established with Firebase. Typically used (with syncState) to change `this.state.loading` to false.
-      - onError: (function - optional) A callback function that will be invoked if the current user does not have read  or write permissions at the location.
+      - onFailure: (function - optional) A callback function that will be invoked if the current user does not have read  or write permissions at the location.
 
 #### Return Value
   An object which you can pass to `removeBinding` when your component unmounts to remove the Firebase listeners.
@@ -162,7 +162,7 @@ addItem(newItem){
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
       - then: (function - optional) The callback function that will be invoked when the initial listener is established with Firebase. Typically used (with bindToState) to change `this.state.loading` to false.
-      - onError: (function - optional) A callback function that will be invoked if the current user does not have read permissions at the location.
+      - onFailure: (function - optional) A callback function that will be invoked if the current user does not have read permissions at the location.
 
 #### Return Value
   An object which you can pass to `removeBinding` when your component unmounts to remove the Firebase listeners.
@@ -196,7 +196,7 @@ componentDidMount(){
       - context: (object - required) The context of your component
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - then: (function - required) The callback function that will be invoked with the data from the specified endpoint when the endpoint changes
-      - onError: (function - optional) The callback function that will be invoked if the current user does not have read permissions at the location.
+      - onFailure: (function - optional) The callback function that will be invoked if the current user does not have read permissions at the location.
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
 
 #### Return Value

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ myApp.delete(() => {
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
       - then: (function - optional) The callback function that will be invoked when the initial listener is established with Firebase. Typically used (with syncState) to change `this.state.loading` to false.
+      - onError: (function - optional) A callback function that will be invoked if the current user does not have read  or write permissions at the location.
 
 #### Return Value
   An object which you can pass to `removeBinding` when your component unmounts to remove the Firebase listeners.
@@ -161,7 +162,7 @@ addItem(newItem){
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
       - then: (function - optional) The callback function that will be invoked when the initial listener is established with Firebase. Typically used (with bindToState) to change `this.state.loading` to false.
-      - onError: (function - optional) The callback function that will be invoked if the current user does not have read permissions at the location.
+      - onError: (function - optional) A callback function that will be invoked if the current user does not have read permissions at the location.
 
 #### Return Value
   An object which you can pass to `removeBinding` when your component unmounts to remove the Firebase listeners.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ componentDidMount(){
       - context: (object - required) The context of your component
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - then: (function - required) The callback function that will be invoked with the data from the specified endpoint when the endpoint changes
+      - onError: (function - optional) The callback function that will be invoked if the current user does not have read permissions at the location.
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
 
 #### Return Value

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ addItem(newItem){
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
       - then: (function - optional) The callback function that will be invoked when the initial listener is established with Firebase. Typically used (with bindToState) to change `this.state.loading` to false.
+      - onError: (function - optional) The callback function that will be invoked if the current user does not have read permissions at the location.
 
 #### Return Value
   An object which you can pass to `removeBinding` when your component unmounts to remove the Firebase listeners.

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -440,7 +440,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        options.then.called = true;
 	      }
 	    }
-	  }));
+	  }, options.onError));
 	};
 
 	exports._addScope = _addScope;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -402,18 +402,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	  refs.set(id, ref);
 	};
 
-	var _updateSyncState = function _updateSyncState(ref, data) {
+	var _handleError = function _handleError(onError, err) {
+	  if (err && typeof onError === 'function') {
+	    onError(err);
+	  }
+	};
+
+	var _updateSyncState = function _updateSyncState(ref, onError, data) {
 	  if (_isObject(data)) {
 	    for (var prop in data) {
 	      //allow timestamps to be set
 	      if (prop !== '.sv') {
-	        _updateSyncState(ref.child(prop), data[prop]);
+	        _updateSyncState(ref.child(prop), onError, data[prop]);
 	      } else {
-	        ref.set(data);
+	        ref.set(data, _handleError.bind(null, onError));
 	      }
 	    }
 	  } else {
-	    ref.set(data);
+	    ref.set(data, _handleError.bind(null, onError));
 	  }
 	};
 
@@ -681,9 +687,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  (0, _utils._firebaseRefsMixin)(id, ref, state.refs);
 	  (0, _utils._addListener)(id, 'syncState', options, ref, state.listeners);
 
+	  options.onError = options.onError ? options.onError : function () {};
 	  var sync = {
 	    id: id,
-	    updateFirebase: _utils._updateSyncState.bind(this, ref),
+	    updateFirebase: _utils._updateSyncState.bind(null, ref, options.onError),
 	    stateKey: options.state
 	  };
 	  (0, _utils._addSync)(options.context, sync, state.syncs);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -402,24 +402,24 @@ return /******/ (function(modules) { // webpackBootstrap
 	  refs.set(id, ref);
 	};
 
-	var _handleError = function _handleError(onError, err) {
-	  if (err && typeof onError === 'function') {
-	    onError(err);
+	var _handleError = function _handleError(onFailure, err) {
+	  if (err && typeof onFailure === 'function') {
+	    onFailure(err);
 	  }
 	};
 
-	var _updateSyncState = function _updateSyncState(ref, onError, data) {
+	var _updateSyncState = function _updateSyncState(ref, onFailure, data) {
 	  if (_isObject(data)) {
 	    for (var prop in data) {
 	      //allow timestamps to be set
 	      if (prop !== '.sv') {
-	        _updateSyncState(ref.child(prop), onError, data[prop]);
+	        _updateSyncState(ref.child(prop), onFailure, data[prop]);
 	      } else {
-	        ref.set(data, _handleError.bind(null, onError));
+	        ref.set(data, _handleError.bind(null, onFailure));
 	      }
 	    }
 	  } else {
-	    ref.set(data, _handleError.bind(null, onError));
+	    ref.set(data, _handleError.bind(null, onFailure));
 	  }
 	};
 
@@ -446,7 +446,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        options.then.called = true;
 	      }
 	    }
-	  }, options.onError));
+	  }, options.onFailure));
 	};
 
 	exports._addScope = _addScope;
@@ -687,10 +687,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  (0, _utils._firebaseRefsMixin)(id, ref, state.refs);
 	  (0, _utils._addListener)(id, 'syncState', options, ref, state.listeners);
 
-	  options.onError = options.onError ? options.onError : function () {};
+	  options.onFailure = options.onFailure ? options.onFailure : function () {};
 	  var sync = {
 	    id: id,
-	    updateFirebase: _utils._updateSyncState.bind(null, ref, options.onError),
+	    updateFirebase: _utils._updateSyncState.bind(null, ref, options.onFailure),
 	    stateKey: options.state
 	  };
 	  (0, _utils._addSync)(options.context, sync, state.syncs);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-base",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "A Relay inspired library for building React.js + Firebase applications.",
   "main": "index.js",
   "repository": {

--- a/src/lib/database/sync.js
+++ b/src/lib/database/sync.js
@@ -28,10 +28,10 @@ export default function _sync(endpoint, options, state){
   _firebaseRefsMixin(id, ref, state.refs);
   _addListener(id, 'syncState', options, ref, state.listeners);
 
-  options.onError = options.onError ? options.onError : () => {};
+  options.onFailure = options.onFailure ? options.onFailure : () => {};
   var sync = {
     id: id,
-    updateFirebase: _updateSyncState.bind(null, ref, options.onError),
+    updateFirebase: _updateSyncState.bind(null, ref, options.onFailure),
     stateKey: options.state
   }
   _addSync(options.context, sync, state.syncs);

--- a/src/lib/database/sync.js
+++ b/src/lib/database/sync.js
@@ -28,9 +28,10 @@ export default function _sync(endpoint, options, state){
   _firebaseRefsMixin(id, ref, state.refs);
   _addListener(id, 'syncState', options, ref, state.listeners);
 
+  options.onError = options.onError ? options.onError : () => {};
   var sync = {
     id: id,
-    updateFirebase: _updateSyncState.bind(this, ref),
+    updateFirebase: _updateSyncState.bind(null, ref, options.onError),
     stateKey: options.state
   }
   _addSync(options.context, sync, state.syncs);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -82,24 +82,24 @@ const _firebaseRefsMixin = function (id, ref, refs){
   refs.set(id, ref);
 };
 
-const _handleError = function(onError, err){
-  if(err && typeof onError === 'function'){
-    onError(err);
+const _handleError = function(onFailure, err){
+  if(err && typeof onFailure === 'function'){
+    onFailure(err);
   }
 }
 
-const _updateSyncState = function (ref, onError, data){
+const _updateSyncState = function (ref, onFailure, data){
   if(_isObject(data)) {
     for(var prop in data){
       //allow timestamps to be set
         if(prop !== '.sv'){
-            _updateSyncState(ref.child(prop), onError, data[prop]);
+            _updateSyncState(ref.child(prop), onFailure, data[prop]);
         } else {
-          ref.set(data, _handleError.bind(null, onError));
+          ref.set(data, _handleError.bind(null, onFailure));
         }
       }
   } else {
-    ref.set(data, _handleError.bind(null, onError));
+    ref.set(data, _handleError.bind(null, onFailure));
   }
 };
 
@@ -126,7 +126,7 @@ const _addListener = function _addListener(id, invoker, options, ref, listeners)
           options.then.called = true;
         }
     }
-  }, options.onError));
+  }, options.onFailure));
 };
 
 export {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -120,7 +120,7 @@ const _addListener = function _addListener(id, invoker, options, ref, listeners)
           options.then.called = true;
         }
     }
-  }));
+  }, options.onError));
 };
 
 export {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -82,18 +82,24 @@ const _firebaseRefsMixin = function (id, ref, refs){
   refs.set(id, ref);
 };
 
-const _updateSyncState = function (ref, data){
+const _handleError = function(onError, err){
+  if(err && typeof onError === 'function'){
+    onError(err);
+  }
+}
+
+const _updateSyncState = function (ref, onError, data){
   if(_isObject(data)) {
     for(var prop in data){
       //allow timestamps to be set
         if(prop !== '.sv'){
-            _updateSyncState(ref.child(prop), data[prop]);
+            _updateSyncState(ref.child(prop), onError, data[prop]);
         } else {
-          ref.set(data);
+          ref.set(data, _handleError.bind(null, onError));
         }
       }
   } else {
-    ref.set(data);
+    ref.set(data, _handleError.bind(null, onError));
   }
 };
 

--- a/tests/specs/bindToState.spec.js
+++ b/tests/specs/bindToState.spec.js
@@ -101,7 +101,7 @@ describe('bindToState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById("mount"));
     });
 
-    it('bindToState() invokes .onError with error if permissions do not allow read', function(done){
+    it('bindToState() invokes .onFailure with error if permissions do not allow read', function(done){
       class TestComponent extends React.Component{
         constructor(props){
           super(props);
@@ -114,7 +114,7 @@ describe('bindToState()', function(){
           this.ref = base.bindToState(`/readFail`, {
             context: this,
             state: 'user',
-            onError(err){
+            onFailure(err){
               expect(err).not.toBeUndefined();
               done();
             }

--- a/tests/specs/bindToState.spec.js
+++ b/tests/specs/bindToState.spec.js
@@ -101,6 +101,36 @@ describe('bindToState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById("mount"));
     });
 
+    it('bindToState() invokes .onError with error if permissions do not allow read', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            loading: true,
+            user: {}
+          }
+        }
+        componentDidMount(){
+          this.ref = base.bindToState(`/readFail`, {
+            context: this,
+            state: 'user',
+            onError(err){
+              expect(err).not.toBeUndefined();
+              done();
+            }
+          });
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          );
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById("mount"));
+    });
+
     it('bindToState() updates its local state with an empty array and object when the Firebase endpoint is null', function(done){
       class TestComponent extends React.Component{
         constructor(props){

--- a/tests/specs/listenTo.spec.js
+++ b/tests/specs/listenTo.spec.js
@@ -127,6 +127,38 @@ describe('listenTo()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('listenTo\'s .onError method gets invoked with error if permissions do not allow read', function(done){
+      var didUpdate = false;
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            data: {}
+          }
+        }
+        componentWillMount(){
+          this.ref = base.listenTo('/readFail', {
+            context: this,
+            onError(err){
+              expect(err).not.toBeUndefined();
+              done();
+            },
+            then(data){
+              done.fail('Database permissions should not allow read from this location');
+            }
+          });
+        }
+        render(){
+          return (
+            <div>
+              Name: {this.state.name} <br />
+              Age: {this.state.age}
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
 
     it('listenTo should return the data as an array if the asArray property of options is set to true', function(done){
       var didUpdate = false;
@@ -189,7 +221,7 @@ describe('listenTo()', function(){
 
       var component1Updated = false;
       var component2Updated = false;
-      
+
       class TestComponent1 extends React.Component{
         constructor(props){
           super(props);

--- a/tests/specs/listenTo.spec.js
+++ b/tests/specs/listenTo.spec.js
@@ -127,7 +127,7 @@ describe('listenTo()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
-    it('listenTo\'s .onError method gets invoked with error if permissions do not allow read', function(done){
+    it('listenTo\'s .onFailure method gets invoked with error if permissions do not allow read', function(done){
       var didUpdate = false;
       class TestComponent extends React.Component{
         constructor(props){
@@ -139,7 +139,7 @@ describe('listenTo()', function(){
         componentWillMount(){
           this.ref = base.listenTo('/readFail', {
             context: this,
-            onError(err){
+            onFailure(err){
               expect(err).not.toBeUndefined();
               done();
             },

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -336,6 +336,64 @@ describe('syncState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('syncState\'s .onError method gets invoked with error if permissions do not allow read', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            loading: true,
+          }
+        }
+        componentDidMount(){
+          this.ref = base.syncState(`/readFail`, {
+            context: this,
+            state: 'user',
+            onError(err){
+              expect(err).not.toBeUndefined();
+              done();
+            }
+          });
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncState\'s .onError method gets invoked with error if permissions do not allow write', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            user: {}
+          }
+        }
+        componentDidMount(){
+          this.ref = base.syncState(`/writeFail`, {
+            context: this,
+            state: 'user',
+            onError(err){
+              expect(err).not.toBeUndefined();
+              done();
+            }
+          });
+          this.setState({user: {name: 'Chris'}});
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
 
     it('syncState() syncs its local state with Firebase as an Array', function(done){
       var setStateCalled = false;

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -336,7 +336,7 @@ describe('syncState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
-    it('syncState\'s .onError method gets invoked with error if permissions do not allow read', function(done){
+    it('syncState\'s .onFailure method gets invoked with error if permissions do not allow read', function(done){
       class TestComponent extends React.Component{
         constructor(props){
           super(props);
@@ -348,7 +348,7 @@ describe('syncState()', function(){
           this.ref = base.syncState(`/readFail`, {
             context: this,
             state: 'user',
-            onError(err){
+            onFailure(err){
               expect(err).not.toBeUndefined();
               done();
             }
@@ -365,7 +365,7 @@ describe('syncState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
-    it('syncState\'s .onError method gets invoked with error if permissions do not allow write', function(done){
+    it('syncState\'s .onFailure method gets invoked with error if permissions do not allow write', function(done){
       class TestComponent extends React.Component{
         constructor(props){
           super(props);
@@ -377,7 +377,7 @@ describe('syncState()', function(){
           this.ref = base.syncState(`/writeFail`, {
             context: this,
             state: 'user',
-            onError(err){
+            onFailure(err){
               expect(err).not.toBeUndefined();
               done();
             }


### PR DESCRIPTION
Fixes #156 and #155 by adding `onFailure` callbacks to `syncState`, `bindToState`, and `listenTo`. The callbacks will receive any permissions related error from firebase (read or write). 