### PR TITLE
Add asString option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ myApp.delete(() => {
       - context: (object - required) The context of your component
       - state: (string - required) The state property you want to sync with Firebase
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
+			- asString: (boolean - optional) Sets state as empty string instead of empty Object or Array if there is no Firebase data
       - isNullable: (boolean - optional) Sets state as null instead of empty Object or Array if there is no Firebase data
       - keepKeys: (boolean - optional) will keep any firebase generated keys intact when manipulating data using the asArray option.
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -339,10 +339,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _prepareData = function _prepareData(snapshot) {
 	  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 	  var isNullable = options.isNullable,
+	      asString = options.asString,
 	      asArray = options.asArray;
 
 	  var data = snapshot.val();
 	  if (~['number', 'boolean'].indexOf(typeof data === 'undefined' ? 'undefined' : _typeof(data))) return data;
+	  if (asString === true && data === null) return '';
 	  if (isNullable === true && data === null) return null;
 	  if (asArray === true) return _toArray(snapshot);
 	  return data === null ? asArray === true ? [] : {} : data;
@@ -544,6 +546,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 	  },
+	  asString: function asString(options) {
+	    this.notObject(options);
+	    if (options.asString === true && (options.isNullable === true || options.asArray === true)) {
+	      (0, _utils._throwError)('The asString option must not be used in conjuntion with the options isNullable or asArray.', 'INVALID_OPTIONS');
+	    }
+	  },
 	  makeError: function makeError(prop, type, actual) {
 	    (0, _utils._throwError)('The options argument must contain a ' + prop + ' property of type ' + type + '. Instead, got ' + actual, 'INVALID_OPTIONS');
 	  }
@@ -637,6 +645,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _fetch(endpoint, options, db) {
 	  (0, _validators._validateEndpoint)(endpoint);
 	  _validators.optionValidators.context(options);
+	  _validators.optionValidators.asString(options);
 	  options.queries && _validators.optionValidators.query(options);
 	  var ref = db.ref(endpoint);
 	  ref = (0, _utils._addQueries)(ref, options.queries);
@@ -701,6 +710,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  (0, _validators._validateEndpoint)(endpoint);
 	  _validators.optionValidators.context(options);
 	  _validators.optionValidators.state(options);
+	  _validators.optionValidators.asString(options);
 	  options.queries && _validators.optionValidators.query(options);
 	  options.then && (options.then.called = false);
 	  options.onFailure = options.onFailure ? options.onFailure.bind(options.context) : function () {};
@@ -774,6 +784,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _bind(endpoint, options, invoker, state) {
 	  (0, _validators._validateEndpoint)(endpoint);
 	  _validators.optionValidators.context(options);
+	  _validators.optionValidators.asString(options);
 	  invoker === 'listenTo' && _validators.optionValidators.then(options);
 	  invoker === 'bindToState' && _validators.optionValidators.state(options);
 	  options.queries && _validators.optionValidators.query(options);

--- a/src/lib/database/bind.js
+++ b/src/lib/database/bind.js
@@ -9,6 +9,7 @@ import {
 export default function _bind(endpoint, options, invoker, state){
   _validateEndpoint(endpoint);
   optionValidators.context(options);
+  optionValidators.asString(options);
   invoker === 'listenTo' && optionValidators.then(options);
   invoker === 'bindToState' && optionValidators.state(options);
   options.queries && optionValidators.query(options);

--- a/src/lib/database/fetch.js
+++ b/src/lib/database/fetch.js
@@ -5,6 +5,7 @@ import { Promise as FirebasePromise } from 'firebase';
 export default function _fetch(endpoint, options, db){
   _validateEndpoint(endpoint);
   optionValidators.context(options);
+  optionValidators.asString(options);
   options.queries && optionValidators.query(options);
   var ref = db.ref(endpoint);
   ref = _addQueries(ref, options.queries);

--- a/src/lib/database/sync.js
+++ b/src/lib/database/sync.js
@@ -13,6 +13,7 @@ export default function _sync(endpoint, options, state){
   _validateEndpoint(endpoint);
   optionValidators.context(options);
   optionValidators.state(options);
+  optionValidators.asString(options);
   options.queries && optionValidators.query(options);
   options.then && (options.then.called = false);
   options.onFailure = options.onFailure ? options.onFailure.bind(options.context) : () => {};

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -15,9 +15,10 @@ const _toArray = function (snapshot){
 };
 
 const _prepareData = function (snapshot, options = {}){
-  const {isNullable, asArray} = options;
+  const {isNullable, asString, asArray} = options;
   const data = snapshot.val();
   if(~['number', 'boolean'].indexOf(typeof data)) return data;
+  if(asString === true && data === null) return '';
   if(isNullable === true && data === null) return null;
   if(asArray === true) return _toArray(snapshot);
   return data === null ? (asArray === true ? [] : {}) : data;

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -43,6 +43,12 @@ const optionValidators = {
       }
     }
   },
+  asString(options){
+    this.notObject(options);
+    if(options.asString === true && (options.isNullable === true || options.asArray === true)) {
+      _throwError(`The asString option must not be used in conjuntion with the options isNullable or asArray`, 'INVALID_OPTIONS');
+    }
+  },
   makeError(prop, type, actual){
     _throwError(`The options argument must contain a ${prop} property of type ${type}. Instead, got ${actual}`, 'INVALID_OPTIONS');
   }

--- a/tests/specs/bindToState.spec.js
+++ b/tests/specs/bindToState.spec.js
@@ -199,6 +199,36 @@ describe('bindToState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById("mount"));
     });
 
+    it('bindToState() updates its local state with empty string "" when the Firebase endpoint is null and asString is true', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            empty: 'someValue'
+          }
+        }
+        componentDidMount(){
+          this.firstRef = base.bindToState(`${testEndpoint}/abcdefg`, {
+            context: this,
+            state: 'empty',
+            asString: true
+          });
+        }
+        componentDidUpdate(){
+          expect(this.state.empty).toEqual('');
+          done();
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById("mount"));
+    });
+
     it('bindToState() properly updates the local state property when the Firebase endpoint changes', function(done){
       class TestComponent extends React.Component{
         constructor(props){

--- a/tests/specs/fetch.spec.js
+++ b/tests/specs/fetch.spec.js
@@ -133,6 +133,17 @@ describe('fetch()', function(){
       });
     });
 
+    it('fetch()\'s asString property should return an empty string "" when there is no Firebase data', function(done){
+      base.fetch(`${testEndpoint}/abcdefg`, {
+        asString: true,
+        context: {},
+        then(data){
+          expect(data).toBe('');
+          done();
+        }
+      });
+    });
+
     it('fetch() returns rejected Promise when read fails or is denied', (done) => {
       base.fetch('/readFail', {context:{}}).then(() => {
         done.fail('Promise should reject')

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -283,6 +283,40 @@ describe('syncState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('syncState() returns an empty string when there is no Firebase data and asString is true', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            data: {}
+          }
+        }
+        componentWillMount(){
+          this.ref = base.syncState(testEndpoint, {
+            context: this,
+            state: 'data',
+            asString: true
+          });
+        }
+        componentDidMount(){
+          ref.child(testEndpoint).set('')
+        }
+        componentDidUpdate(){
+          expect(this.state.data).toEqual('');
+          ReactDOM.unmountComponentAtNode(document.body);
+          done();
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
 
     it('syncState() returns an array when there is data that was previously bound to another endpoint', function(done){
       ref.child(`${testEndpoint}/child2`).set(dummyArrData).then(() => {


### PR DESCRIPTION
> `boolean` `optional`
> 
> Sets state as empty string instead of empty Object or Array if there is no Firebase data.

- [x] Added a validator: cannot be used in conjunction with isNullable or asArray
- [x] Added tests for fetch, bindToState, syncState and they are passing

Idea behind the pull request: [React emits a warning if an input is `null`, see react#6996](https://github.com/facebook/react/issues/6996). I was using `isNullable` and incurred in the warning while syncingState. I was about to open an issue, but… :)