### PR TITLE
Add defaultValue option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ myApp.delete(() => {
     - properties:
       - context: (object - required) The context of your component
       - state: (string - required) The state property you want to sync with Firebase
+			- defaultValue: (string|boolean|number|object - optional) A default value to set when the Firebase endpoint is null (i.e., on init) (instead of empty Object or Array)
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
       - keepKeys: (boolean - optional) will keep any firebase generated keys intact when manipulating data using the asArray option.
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ myApp.delete(() => {
       - context: (object - required) The context of your component
       - state: (string - required) The state property you want to sync with Firebase
       - asArray: (boolean - optional) Returns the Firebase data at the specified endpoint as an Array instead of an Object
-			- asString: (boolean - optional) Sets state as empty string instead of empty Object or Array if there is no Firebase data
-      - isNullable: (boolean - optional) Sets state as null instead of empty Object or Array if there is no Firebase data
       - keepKeys: (boolean - optional) will keep any firebase generated keys intact when manipulating data using the asArray option.
       - queries: (object - optional) Queries to be used with your read operations.  See [Query Options](#queries) for more details.
       - then: (function - optional) The callback function that will be invoked when the initial listener is established with Firebase. Typically used (with syncState) to change `this.state.loading` to false.

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -316,6 +316,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  value: true
 	});
 
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 	var _isObject = function _isObject(obj) {
@@ -334,15 +336,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return arr;
 	};
 
+	var _isValid = function _isValid(value) {
+	  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || (typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' ? true : false;
+	};
+
 	var _prepareData = function _prepareData(snapshot) {
 	  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-	  var isNullable = options.isNullable,
-	      asString = options.asString,
+	  var defaultValue = options.defaultValue,
 	      asArray = options.asArray;
 
 	  var data = snapshot.val();
-	  if (asString === true && data === null) return '';
-	  if (isNullable === true && data === null) return null;
+	  if (data === null && _isValid(defaultValue)) return defaultValue;
 	  if (asArray === true) return _toArray(snapshot);
 	  return data === null ? {} : data;
 	};
@@ -482,6 +486,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports._throwError = _throwError;
 	exports._prepareData = _prepareData;
 	exports._toArray = _toArray;
+	exports._isValid = _isValid;
 	exports._isObject = _isObject;
 	exports._addSync = _addSync;
 	exports._firebaseRefsMixin = _firebaseRefsMixin;
@@ -543,10 +548,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 	  },
-	  asString: function asString(options) {
+	  defaultValue: function defaultValue(options) {
 	    this.notObject(options);
-	    if (options.asString === true && (options.isNullable === true || options.asArray === true)) {
-	      (0, _utils._throwError)('The asString option must not be used in conjuntion with the options isNullable or asArray', 'INVALID_OPTIONS');
+	    if (options.hasOwnProperty('defaultValue')) {
+	      if (!(0, _utils._isValid)(options.defaultValue)) {
+	        (0, _utils._throwError)('The typeof defaultValue must be one of string, number, boolean, object.', 'INVALID_OPTIONS');
+	      }
 	    }
 	  },
 	  makeError: function makeError(prop, type, actual) {
@@ -642,7 +649,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _fetch(endpoint, options, db) {
 	  (0, _validators._validateEndpoint)(endpoint);
 	  _validators.optionValidators.context(options);
-	  _validators.optionValidators.asString(options);
+	  _validators.optionValidators.defaultValue(options);
 	  options.queries && _validators.optionValidators.query(options);
 	  var ref = db.ref(endpoint);
 	  ref = (0, _utils._addQueries)(ref, options.queries);
@@ -707,7 +714,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  (0, _validators._validateEndpoint)(endpoint);
 	  _validators.optionValidators.context(options);
 	  _validators.optionValidators.state(options);
-	  _validators.optionValidators.asString(options);
+	  _validators.optionValidators.defaultValue(options);
 	  options.queries && _validators.optionValidators.query(options);
 	  options.then && (options.then.called = false);
 	  options.onFailure = options.onFailure ? options.onFailure.bind(options.context) : function () {};
@@ -781,7 +788,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _bind(endpoint, options, invoker, state) {
 	  (0, _validators._validateEndpoint)(endpoint);
 	  _validators.optionValidators.context(options);
-	  _validators.optionValidators.asString(options);
+	  _validators.optionValidators.defaultValue(options);
 	  invoker === 'listenTo' && _validators.optionValidators.then(options);
 	  invoker === 'bindToState' && _validators.optionValidators.state(options);
 	  options.queries && _validators.optionValidators.query(options);

--- a/src/lib/database/bind.js
+++ b/src/lib/database/bind.js
@@ -9,7 +9,7 @@ import {
 export default function _bind(endpoint, options, invoker, state){
   _validateEndpoint(endpoint);
   optionValidators.context(options);
-  optionValidators.asString(options);
+  optionValidators.defaultValue(options);
   invoker === 'listenTo' && optionValidators.then(options);
   invoker === 'bindToState' && optionValidators.state(options);
   options.queries && optionValidators.query(options);

--- a/src/lib/database/fetch.js
+++ b/src/lib/database/fetch.js
@@ -5,7 +5,7 @@ import { Promise as FirebasePromise } from 'firebase';
 export default function _fetch(endpoint, options, db){
   _validateEndpoint(endpoint);
   optionValidators.context(options);
-  optionValidators.asString(options);
+  optionValidators.defaultValue(options);
   options.queries && optionValidators.query(options);
   var ref = db.ref(endpoint);
   ref = _addQueries(ref, options.queries);

--- a/src/lib/database/sync.js
+++ b/src/lib/database/sync.js
@@ -13,7 +13,7 @@ export default function _sync(endpoint, options, state){
   _validateEndpoint(endpoint);
   optionValidators.context(options);
   optionValidators.state(options);
-  optionValidators.asString(options);
+  optionValidators.defaultValue(options);
   options.queries && optionValidators.query(options);
   options.then && (options.then.called = false);
   options.onFailure = options.onFailure ? options.onFailure.bind(options.context) : () => {};

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -15,10 +15,8 @@ const _toArray = function (snapshot){
 };
 
 const _prepareData = function (snapshot, options = {}){
-  const {isNullable, asString, asArray} = options;
+  const {asArray} = options;
   const data = snapshot.val();
-  if(asString === true && data === null) return '';
-  if(isNullable === true && data === null) return null;
   if(asArray === true) return _toArray(snapshot);
   return data === null ? {} : data;
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -19,8 +19,9 @@ const _isValid = function (value) {
 }
 
 const _prepareData = function (snapshot, options = {}){
-  const {asArray} = options;
+  const {defaultValue, asArray} = options;
   const data = snapshot.val();
+  if(data === null && _isValid(defaultValue)) return defaultValue;
   if(asArray === true) return _toArray(snapshot);
   return data === null ? {} : data;
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -14,6 +14,10 @@ const _toArray = function (snapshot){
   return arr;
 };
 
+const _isValid = function (value) {
+  return (typeof value ===  'string' || typeof value === 'number' || typeof value === 'boolean' || typeof value === 'object') ? true : false;
+}
+
 const _prepareData = function (snapshot, options = {}){
   const {asArray} = options;
   const data = snapshot.val();
@@ -157,6 +161,7 @@ export {
   _throwError,
   _prepareData,
   _toArray,
+  _isValid,
   _isObject,
   _addSync,
   _firebaseRefsMixin,

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -1,5 +1,6 @@
 import {
   _isObject,
+  _isValid,
   _throwError
 } from './utils';
 
@@ -40,6 +41,14 @@ const optionValidators = {
     for(var key in queries){
       if(queries.hasOwnProperty(key) && validQueries.indexOf(key) === -1){
         _throwError(`The query field must contain valid Firebase queries.  Expected one of [${validQueries.join(', ')}]. Instead, got ${key}`, 'INVALID_OPTIONS');
+      }
+    }
+  },
+  defaultValue(options){
+    this.notObject(options);
+    if (options.hasOwnProperty('defaultValue')) {
+      if (!_isValid(options.defaultValue)) {
+        _throwError(`The typeof defaultValue must be one of string, number, boolean, object.`, 'INVALID_OPTIONS');
       }
     }
   },

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -43,12 +43,6 @@ const optionValidators = {
       }
     }
   },
-  asString(options){
-    this.notObject(options);
-    if(options.asString === true && (options.isNullable === true || options.asArray === true)) {
-      _throwError(`The asString option must not be used in conjuntion with the options isNullable or asArray`, 'INVALID_OPTIONS');
-    }
-  },
   makeError(prop, type, actual){
     _throwError(`The options argument must contain a ${prop} property of type ${type}. Instead, got ${actual}`, 'INVALID_OPTIONS');
   }

--- a/tests/specs/bindToState.spec.js
+++ b/tests/specs/bindToState.spec.js
@@ -169,66 +169,6 @@ describe('bindToState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById("mount"));
     });
 
-    it('bindToState() updates its local state with null when the Firebase endpoint is null and isNullable is true', function(done){
-      class TestComponent extends React.Component{
-        constructor(props){
-          super(props);
-          this.state = {
-            empty: 'someValue'
-          }
-        }
-        componentDidMount(){
-          this.firstRef = base.bindToState(`${testEndpoint}/abcdefg`, {
-            context: this,
-            state: 'empty',
-            isNullable: true
-          });
-        }
-        componentDidUpdate(){
-          expect(this.state.empty).toBeNull();
-          done();
-        }
-        render(){
-          return (
-            <div>
-              No Data
-            </div>
-          )
-        }
-      }
-      ReactDOM.render(<TestComponent />, document.getElementById("mount"));
-    });
-
-    it('bindToState() updates its local state with empty string "" when the Firebase endpoint is null and asString is true', function(done){
-      class TestComponent extends React.Component{
-        constructor(props){
-          super(props);
-          this.state = {
-            empty: 'someValue'
-          }
-        }
-        componentDidMount(){
-          this.firstRef = base.bindToState(`${testEndpoint}/abcdefg`, {
-            context: this,
-            state: 'empty',
-            asString: true
-          });
-        }
-        componentDidUpdate(){
-          expect(this.state.empty).toEqual('');
-          done();
-        }
-        render(){
-          return (
-            <div>
-              No Data
-            </div>
-          )
-        }
-      }
-      ReactDOM.render(<TestComponent />, document.getElementById("mount"));
-    });
-
     it('bindToState() properly updates the local state property when the Firebase endpoint changes', function(done){
       class TestComponent extends React.Component{
         constructor(props){

--- a/tests/specs/bindToState.spec.js
+++ b/tests/specs/bindToState.spec.js
@@ -169,6 +169,36 @@ describe('bindToState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById("mount"));
     });
 
+    it('bindToState() updates its local state with defaultValue when the Firebase endpoint is null and defaultValue is set', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            empty: 'someValue'
+          }
+        }
+        componentDidMount(){
+          this.firstRef = base.bindToState(`${testEndpoint}/abcdefg`, {
+            context: this,
+            state: 'empty',
+            defaultValue: 0
+          });
+        }
+        componentDidUpdate(){
+          expect(this.state.empty).toEqual(0);
+          done();
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById("mount"));
+    });
+
     it('bindToState() properly updates the local state property when the Firebase endpoint changes', function(done){
       class TestComponent extends React.Component{
         constructor(props){

--- a/tests/specs/fetch.spec.js
+++ b/tests/specs/fetch.spec.js
@@ -133,17 +133,6 @@ describe('fetch()', function(){
       });
     });
 
-    it('fetch()\'s asString property should return an empty string "" when there is no Firebase data', function(done){
-      base.fetch(`${testEndpoint}/abcdefg`, {
-        asString: true,
-        context: {},
-        then(data){
-          expect(data).toBe('');
-          done();
-        }
-      });
-    });
-
     it('fetch() returns rejected Promise when read fails or is denied', (done) => {
       base.fetch('/readFail', {context:{}}).then(() => {
         done.fail('Promise should reject')

--- a/tests/specs/fetch.spec.js
+++ b/tests/specs/fetch.spec.js
@@ -133,6 +133,17 @@ describe('fetch()', function(){
       });
     });
 
+    it('fetch()\'s defaultValue returns defaultValue when there is no Firebase data', function(done){
+      base.fetch(`${testEndpoint}/abcdefg`, {
+        defaultValue: 'test',
+        context: {},
+        then(data){
+          expect(data).toBe('test');
+          done();
+        }
+      });
+    });
+
     it('fetch() returns rejected Promise when read fails or is denied', (done) => {
       base.fetch('/readFail', {context:{}}).then(() => {
         done.fail('Promise should reject')

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -249,6 +249,74 @@ describe('syncState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('syncState() returns defaultValue when there is no Firebase data and defaultValue is set', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            data: {}
+          }
+        }
+        componentWillMount(){
+          this.ref = base.syncState(testEndpoint, {
+            context: this,
+            state: 'data',
+            defaultValue: true
+          });
+        }
+        componentDidMount(){
+          ref.child(testEndpoint).set(true)
+        }
+        componentDidUpdate(){
+          expect(this.state.data).toEqual(true);
+          ReactDOM.unmountComponentAtNode(document.body);
+          done();
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncState() returns defaultValue when there is no Firebase data, asArray is true and defaultValue is set', function(done){
+      class TestComponent extends React.Component{
+        constructor(props){
+          super(props);
+          this.state = {
+            data: {}
+          }
+        }
+        componentWillMount(){
+          this.ref = base.syncState(testEndpoint, {
+            context: this,
+            state: 'data',
+            asArray: true,
+            defaultValue: null
+          });
+        }
+        componentDidMount(){
+          ref.child(testEndpoint).set(null)
+        }
+        componentDidUpdate(){
+          expect(this.state.data).toBeNull();
+          ReactDOM.unmountComponentAtNode(document.body);
+          done();
+        }
+        render(){
+          return (
+            <div>
+              No Data
+            </div>
+          )
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
 
     it('syncState() returns an array when there is data that was previously bound to another endpoint', function(done){
       ref.child(`${testEndpoint}/child2`).set(dummyArrData).then(() => {

--- a/tests/specs/syncState.spec.js
+++ b/tests/specs/syncState.spec.js
@@ -249,74 +249,6 @@ describe('syncState()', function(){
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
-    it('syncState() returns a null when there is no Firebase data and asArray is false, isNullable is true', function(done){
-      class TestComponent extends React.Component{
-        constructor(props){
-          super(props);
-          this.state = {
-            data: {}
-          }
-        }
-        componentWillMount(){
-          this.ref = base.syncState(testEndpoint, {
-            context: this,
-            state: 'data',
-            isNullable: true
-          });
-        }
-        componentDidMount(){
-          ref.child(testEndpoint).set(null)
-        }
-        componentDidUpdate(){
-          expect(this.state.data).toBeNull();
-          ReactDOM.unmountComponentAtNode(document.body);
-          done();
-        }
-        render(){
-          return (
-            <div>
-              No Data
-            </div>
-          )
-        }
-      }
-      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
-    });
-
-    it('syncState() returns an empty string when there is no Firebase data and asString is true', function(done){
-      class TestComponent extends React.Component{
-        constructor(props){
-          super(props);
-          this.state = {
-            data: {}
-          }
-        }
-        componentWillMount(){
-          this.ref = base.syncState(testEndpoint, {
-            context: this,
-            state: 'data',
-            asString: true
-          });
-        }
-        componentDidMount(){
-          ref.child(testEndpoint).set('')
-        }
-        componentDidUpdate(){
-          expect(this.state.data).toEqual('');
-          ReactDOM.unmountComponentAtNode(document.body);
-          done();
-        }
-        render(){
-          return (
-            <div>
-              No Data
-            </div>
-          )
-        }
-      }
-      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
-    });
-
 
     it('syncState() returns an array when there is data that was previously bound to another endpoint', function(done){
       ref.child(`${testEndpoint}/child2`).set(dummyArrData).then(() => {
@@ -377,40 +309,6 @@ describe('syncState()', function(){
         }
         componentDidUpdate(){
           expect(this.state.messages).toEqual([]);
-          done();
-        }
-        render(){
-          return (
-            <div>
-              No Data
-            </div>
-          )
-        }
-      }
-      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
-    });
-
-    it('syncState() returns a null when there is no Firebase data and asArray is true, isNullable is true', function(done){
-      class TestComponent extends React.Component{
-        constructor(props){
-          super(props);
-          this.state = {
-            messages: []
-          }
-        }
-        componentWillMount(){
-          this.ref = base.syncState(testEndpoint, {
-            context: this,
-            state: 'messages',
-            asArray: true,
-            isNullable: true
-          });
-        }
-        componentDidMount(){
-          ref.child(testEndpoint).set(null);
-        }
-        componentDidUpdate(){
-          expect(this.state.messages).toBeNull();
           done();
         }
         render(){


### PR DESCRIPTION
Removes `asString` and `isNullable` to allow for an arbitrary `string|boolean|number|object` default value when the Firebase endpoint is `null`. Works with `asArray`. Tests are passing, although:
- [ ] I'm not testing each of the four possible types
- [ ] Invalid option regarding `defaultValue` is missing in tests