### PR TITLE
Firestore support 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,14 @@
 {
   "env": {
     "test": {
-      "plugins": [ "istanbul" ]
+      "plugins": [
+        [
+          "istanbul",
+          {
+            "exclude": ["tests/**/*"]
+          }
+        ]
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ addBear(){
 
 #### Purpose
   Allows you to update data at a Firebase endpoint changing only the properties you pass to it.
-  **Warning: calling update with `options.data` being null will remove the all the data at that endpoint**
+  **Warning: calling update with `options.data` being null will remove all the data at that endpoint**
 
 #### Arguments
   1. endpoint

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1,13 +1,13 @@
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory();
+		module.exports = factory(require("firebase/app"));
 	else if(typeof define === 'function' && define.amd)
-		define([], factory);
+		define(["firebase/app"], factory);
 	else {
-		var a = factory();
+		var a = typeof exports === 'object' ? factory(require("firebase/app")) : factory(root["firebase/app"]);
 		for(var i in a) (typeof exports === 'object' ? exports : root)[i] = a[i];
 	}
-})(this, function() {
+})(this, function(__WEBPACK_EXTERNAL_MODULE_6__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -67,31 +67,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _validators = __webpack_require__(5);
 
-	var _push2 = __webpack_require__(6);
+	var _push2 = __webpack_require__(7);
 
 	var _push3 = _interopRequireDefault(_push2);
 
-	var _fetch2 = __webpack_require__(7);
+	var _fetch2 = __webpack_require__(8);
 
 	var _fetch3 = _interopRequireDefault(_fetch2);
 
-	var _post2 = __webpack_require__(8);
+	var _post2 = __webpack_require__(9);
 
 	var _post3 = _interopRequireDefault(_post2);
 
-	var _sync2 = __webpack_require__(9);
+	var _sync2 = __webpack_require__(10);
 
 	var _sync3 = _interopRequireDefault(_sync2);
 
-	var _bind2 = __webpack_require__(10);
+	var _bind2 = __webpack_require__(11);
 
 	var _bind3 = _interopRequireDefault(_bind2);
 
-	var _update2 = __webpack_require__(11);
+	var _update2 = __webpack_require__(12);
 
 	var _update3 = _interopRequireDefault(_update2);
 
-	var _reset2 = __webpack_require__(12);
+	var _reset2 = __webpack_require__(13);
 
 	var _reset3 = _interopRequireDefault(_reset2);
 
@@ -99,11 +99,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _removeBinding3 = _interopRequireDefault(_removeBinding2);
 
-	var _remove2 = __webpack_require__(13);
+	var _remove2 = __webpack_require__(14);
 
 	var _remove3 = _interopRequireDefault(_remove2);
 
-	var _fsSync2 = __webpack_require__(14);
+	var _fsSync2 = __webpack_require__(15);
 
 	var _fsSync3 = _interopRequireDefault(_fsSync2);
 
@@ -111,31 +111,31 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _fsRemoveBinding3 = _interopRequireDefault(_fsRemoveBinding2);
 
-	var _fsBind2 = __webpack_require__(15);
+	var _fsBind2 = __webpack_require__(16);
 
 	var _fsBind3 = _interopRequireDefault(_fsBind2);
 
-	var _fsGet2 = __webpack_require__(16);
+	var _fsGet2 = __webpack_require__(17);
 
 	var _fsGet3 = _interopRequireDefault(_fsGet2);
 
-	var _fsRemoveDoc2 = __webpack_require__(17);
+	var _fsRemoveDoc2 = __webpack_require__(18);
 
 	var _fsRemoveDoc3 = _interopRequireDefault(_fsRemoveDoc2);
 
-	var _fsAddToCollection2 = __webpack_require__(18);
+	var _fsAddToCollection2 = __webpack_require__(19);
 
 	var _fsAddToCollection3 = _interopRequireDefault(_fsAddToCollection2);
 
-	var _fsRemoveFromCollection2 = __webpack_require__(19);
+	var _fsRemoveFromCollection2 = __webpack_require__(20);
 
 	var _fsRemoveFromCollection3 = _interopRequireDefault(_fsRemoveFromCollection2);
 
-	var _fsUpdateDoc2 = __webpack_require__(20);
+	var _fsUpdateDoc2 = __webpack_require__(21);
 
 	var _fsUpdateDoc3 = _interopRequireDefault(_fsUpdateDoc2);
 
-	var _fsReset2 = __webpack_require__(21);
+	var _fsReset2 = __webpack_require__(22);
 
 	var _fsReset3 = _interopRequireDefault(_fsReset2);
 
@@ -299,7 +299,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	exports._fsSetUnmountHandler = exports._setData = exports._handleError = exports._createNestedObject = exports._setUnmountHandler = exports._addFirestoreListener = exports._addListener = exports._fsUpdateSyncState = exports._updateSyncState = exports._firebaseRefsMixin = exports._addSync = exports._hasOwnNestedProperty = exports._getNestedObject = exports._isNestedPath = exports._isObject = exports._isValid = exports._toArray = exports._fsPrepareData = exports._prepareData = exports._throwError = exports._setState = exports._returnRef = exports._addFirestoreQuery = exports._addQueries = exports._getSegmentCount = exports._createHash = undefined;
+	exports._fsCreateRef = exports._fsSetUnmountHandler = exports._setData = exports._handleError = exports._createNestedObject = exports._setUnmountHandler = exports._addFirestoreListener = exports._addListener = exports._fsUpdateSyncState = exports._updateSyncState = exports._firebaseRefsMixin = exports._addSync = exports._hasOwnNestedProperty = exports._getSegmentCount = exports._getNestedObject = exports._isNestedPath = exports._isObject = exports._isValid = exports._toArray = exports._fsPrepareData = exports._prepareData = exports._throwError = exports._setState = exports._returnRef = exports._addFirestoreQuery = exports._addQueries = exports._createHash = undefined;
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -657,8 +657,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return options.state ? _defineProperty({}, options.state, collection) : collection;
 	};
 
+	var _fsCreateRef = function _fsCreateRef(pathOrRef, db) {
+	  if ((typeof pathOrRef === 'undefined' ? 'undefined' : _typeof(pathOrRef)) === 'object') {
+	    return pathOrRef;
+	  }
+	  var segmentCount = _getSegmentCount(pathOrRef);
+	  var ref;
+	  if (segmentCount % 2 === 0) {
+	    ref = db.doc(pathOrRef);
+	  } else {
+	    ref = db.collection(pathOrRef);
+	  }
+	  return ref;
+	};
+
 	exports._createHash = _createHash;
-	exports._getSegmentCount = _getSegmentCount;
 	exports._addQueries = _addQueries;
 	exports._addFirestoreQuery = _addFirestoreQuery;
 	exports._returnRef = _returnRef;
@@ -671,6 +684,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports._isObject = _isObject;
 	exports._isNestedPath = _isNestedPath;
 	exports._getNestedObject = _getNestedObject;
+	exports._getSegmentCount = _getSegmentCount;
 	exports._hasOwnNestedProperty = _hasOwnNestedProperty;
 	exports._addSync = _addSync;
 	exports._firebaseRefsMixin = _firebaseRefsMixin;
@@ -683,6 +697,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports._handleError = _handleError;
 	exports._setData = _setData;
 	exports._fsSetUnmountHandler = _fsSetUnmountHandler;
+	exports._fsCreateRef = _fsCreateRef;
 
 /***/ }),
 /* 3 */
@@ -779,6 +794,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _utils = __webpack_require__(2);
 
+	var _app = __webpack_require__(6);
+
+	var _app2 = _interopRequireDefault(_app);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 	var optionValidators = {
 	  notObject: function notObject(options) {
 	    if (!(0, _utils._isObject)(options)) {
@@ -833,6 +854,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var _validateEndpoint = function _validateEndpoint(endpoint) {
+	  if (_app2.default.firestore) {
+	    var _firebase$firestore = _app2.default.firestore,
+	        DocumentReference = _firebase$firestore.DocumentReference,
+	        CollectionReference = _firebase$firestore.CollectionReference;
+
+	    if ((typeof endpoint === 'undefined' ? 'undefined' : _typeof(endpoint)) === 'object') {
+	      if (endpoint instanceof DocumentReference || endpoint instanceof CollectionReference) {
+	        return;
+	      }
+	    }
+	  }
 	  var defaultError = 'The Firebase endpoint you are trying to listen to';
 	  var errorMsg;
 	  if (typeof endpoint !== 'string') {
@@ -862,14 +894,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 	var _validateDocumentPath = function _validateDocumentPath(path) {
-	  var defaultError = 'Invalid document path.';
+	  var DocumentReference = _app2.default.firestore.DocumentReference;
+
+	  if ((typeof path === 'undefined' ? 'undefined' : _typeof(path)) === 'object' && path instanceof DocumentReference) return;
+	  var defaultError = 'Invalid document path or reference.';
 	  if (typeof path !== 'string') (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
 	  var segmentCount = (0, _utils._getSegmentCount)(path);
 	  if (segmentCount % 2 !== 0) (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
 	};
 
 	var _validateCollectionPath = function _validateCollectionPath(path) {
-	  var defaultError = 'Invalid collection path.';
+	  var CollectionReference = _app2.default.firestore.CollectionReference;
+
+	  if ((typeof path === 'undefined' ? 'undefined' : _typeof(path)) === 'object' && path instanceof CollectionReference) return;
+	  var defaultError = 'Invalid collection path or reference.';
 	  if (typeof path !== 'string') (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
 	  var segmentCount = (0, _utils._getSegmentCount)(path);
 	  if (segmentCount % 2 === 0) (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
@@ -883,6 +921,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ }),
 /* 6 */
+/***/ (function(module, exports) {
+
+	module.exports = __WEBPACK_EXTERNAL_MODULE_6__;
+
+/***/ }),
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -908,7 +952,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 7 */
+/* 8 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -945,7 +989,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 8 */
+/* 9 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -969,7 +1013,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 9 */
+/* 10 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1071,7 +1115,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 10 */
+/* 11 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1103,7 +1147,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 11 */
+/* 12 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1127,7 +1171,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 12 */
+/* 13 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -1147,7 +1191,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 13 */
+/* 14 */
 /***/ (function(module, exports) {
 
 	"use strict";
@@ -1161,7 +1205,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 14 */
+/* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1189,7 +1233,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  options.reactSetState = _fsSync.reactSetState;
 
 	  var id = (0, _utils._createHash)(document, 'syncDoc');
-	  var ref = state.db.doc(document);
+	  var ref = (0, _utils._fsCreateRef)(document, state.db);
 	  (0, _utils._firebaseRefsMixin)(id, ref, state.refs);
 	  (0, _utils._addFirestoreListener)(id, 'syncDoc', options, ref, state.listeners);
 	  (0, _utils._fsSetUnmountHandler)(options.context, id, state.refs, state.listeners, state.syncs);
@@ -1250,7 +1294,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 15 */
+/* 16 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1266,6 +1310,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function _fsBind(path, options, invoker, state) {
 	  _validators.optionValidators.context(options);
+	  options.then && (options.then.called = false);
 	  if (invoker === 'bindDoc') {
 	    (0, _validators._validateDocumentPath)(path);
 	  }
@@ -1281,17 +1326,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	    (0, _validators._validateCollectionPath)(path);
 	    _validators.optionValidators.then(options);
 	  }
-
-	  options.then && (options.then.called = false);
-
+	  var ref = (0, _utils._fsCreateRef)(path, state.db);
 	  var id = (0, _utils._createHash)(path, invoker);
-	  var segmentCount = (0, _utils._getSegmentCount)(path);
-	  var ref;
-	  if (segmentCount % 2 === 0) {
-	    ref = state.db.doc(path);
-	  } else {
-	    ref = state.db.collection(path);
-	  }
 	  (0, _utils._firebaseRefsMixin)(id, ref, state.refs);
 	  (0, _utils._addFirestoreListener)(id, invoker, options, ref, state.listeners);
 	  (0, _utils._fsSetUnmountHandler)(options.context, id, state.refs, state.listeners, state.syncs);
@@ -1299,7 +1335,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 16 */
+/* 17 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1318,15 +1354,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var db = arguments[2];
 
 	  (0, _validators._validateEndpoint)(endpoint);
-	  var segmentCount = (0, _utils._getSegmentCount)(endpoint);
-	  var isCollection = segmentCount % 2 !== 0;
-	  var ref;
-	  if (isCollection) {
-	    ref = db.collection(endpoint);
-	    ref = (0, _utils._addFirestoreQuery)(ref, options.query);
-	  } else {
-	    ref = db.doc(endpoint);
-	  }
+	  var ref = (0, _utils._fsCreateRef)(endpoint, db);
+	  //check if ref is a collection
+	  var isCollection = !!ref.add;
+	  ref = (0, _utils._addFirestoreQuery)(ref, options.query);
 	  return ref.get().then(function (snapshot) {
 	    if (isCollection && !snapshot.empty || !isCollection && snapshot.exists) {
 	      return (0, _utils._fsPrepareData)(snapshot, options, isCollection);
@@ -1334,20 +1365,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return Promise.reject(new Error('No Result'));
 	    }
 	  });
-	}
-
-/***/ }),
-/* 17 */
-/***/ (function(module, exports) {
-
-	"use strict";
-
-	Object.defineProperty(exports, "__esModule", {
-	  value: true
-	});
-	exports.default = _fsRemoveDoc;
-	function _fsRemoveDoc(path, db) {
-	  return db.doc(path).delete();
 	}
 
 /***/ }),
@@ -1359,20 +1376,41 @@ return /******/ (function(modules) { // webpackBootstrap
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	exports.default = _fsAddToCollection;
+	exports.default = _fsRemoveDoc;
 
-	var _validators = __webpack_require__(5);
+	var _utils = __webpack_require__(2);
 
-	function _fsAddToCollection(path, doc, db, key) {
-	  (0, _validators._validateCollectionPath)(path);
-	  if (key) {
-	    return db.collection(path).doc(key).set(doc);
-	  }
-	  return db.collection(path).add(doc);
+	function _fsRemoveDoc(path, db) {
+	  var ref = (0, _utils._fsCreateRef)(path, db);
+	  return ref.delete();
 	}
 
 /***/ }),
 /* 19 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsAddToCollection;
+
+	var _validators = __webpack_require__(5);
+
+	var _utils = __webpack_require__(2);
+
+	function _fsAddToCollection(path, doc, db, key) {
+	  (0, _validators._validateCollectionPath)(path);
+	  var ref = (0, _utils._fsCreateRef)(path, db);
+	  if (key) {
+	    return ref.doc(key).set(doc);
+	  }
+	  return ref.add(doc);
+	}
+
+/***/ }),
+/* 20 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1390,7 +1428,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
 	  (0, _validators._validateCollectionPath)(path);
-	  var ref = db.collection(path);
+	  var ref = (0, _utils._fsCreateRef)(path, db);
 	  ref = (0, _utils._addFirestoreQuery)(ref, options.query);
 	  return ref.get().then(function (snapshot) {
 	    if (!snapshot.empty) {
@@ -1404,7 +1442,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 20 */
+/* 21 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -1416,13 +1454,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _validators = __webpack_require__(5);
 
+	var _utils = __webpack_require__(2);
+
 	function _fsUpdateDoc(document, data, db) {
 	  (0, _validators._validateDocumentPath)(document);
-	  return db.doc(document).update(data);
+	  var ref = (0, _utils._fsCreateRef)(document, db);
+	  return ref.update(data);
 	}
 
 /***/ }),
-/* 21 */
+/* 22 */
 /***/ (function(module, exports) {
 
 	"use strict";

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -472,7 +472,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _createHash = function _createHash(endpoint, invoker) {
 	  var hash = 0;
 	  var str = endpoint + invoker + Math.random();
-	  if (str.length == 0) return hash;
 	  for (var i = 0; i < str.length; i++) {
 	    var char = str.charCodeAt(i);
 	    hash = (hash << 5) - hash + char;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -65,33 +65,33 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _utils = __webpack_require__(2);
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
-	var _push2 = __webpack_require__(5);
+	var _push2 = __webpack_require__(6);
 
 	var _push3 = _interopRequireDefault(_push2);
 
-	var _fetch2 = __webpack_require__(6);
+	var _fetch2 = __webpack_require__(7);
 
 	var _fetch3 = _interopRequireDefault(_fetch2);
 
-	var _post2 = __webpack_require__(7);
+	var _post2 = __webpack_require__(8);
 
 	var _post3 = _interopRequireDefault(_post2);
 
-	var _sync2 = __webpack_require__(8);
+	var _sync2 = __webpack_require__(9);
 
 	var _sync3 = _interopRequireDefault(_sync2);
 
-	var _bind2 = __webpack_require__(9);
+	var _bind2 = __webpack_require__(10);
 
 	var _bind3 = _interopRequireDefault(_bind2);
 
-	var _update2 = __webpack_require__(10);
+	var _update2 = __webpack_require__(11);
 
 	var _update3 = _interopRequireDefault(_update2);
 
-	var _reset2 = __webpack_require__(11);
+	var _reset2 = __webpack_require__(12);
 
 	var _reset3 = _interopRequireDefault(_reset2);
 
@@ -99,76 +99,179 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _removeBinding3 = _interopRequireDefault(_removeBinding2);
 
-	var _remove2 = __webpack_require__(12);
+	var _remove2 = __webpack_require__(13);
 
 	var _remove3 = _interopRequireDefault(_remove2);
 
+	var _fsSync2 = __webpack_require__(14);
+
+	var _fsSync3 = _interopRequireDefault(_fsSync2);
+
+	var _fsRemoveBinding2 = __webpack_require__(4);
+
+	var _fsRemoveBinding3 = _interopRequireDefault(_fsRemoveBinding2);
+
+	var _fsBind2 = __webpack_require__(15);
+
+	var _fsBind3 = _interopRequireDefault(_fsBind2);
+
+	var _fsGet2 = __webpack_require__(16);
+
+	var _fsGet3 = _interopRequireDefault(_fsGet2);
+
+	var _fsRemoveDoc2 = __webpack_require__(17);
+
+	var _fsRemoveDoc3 = _interopRequireDefault(_fsRemoveDoc2);
+
+	var _fsAddToCollection2 = __webpack_require__(18);
+
+	var _fsAddToCollection3 = _interopRequireDefault(_fsAddToCollection2);
+
+	var _fsRemoveFromCollection2 = __webpack_require__(19);
+
+	var _fsRemoveFromCollection3 = _interopRequireDefault(_fsRemoveFromCollection2);
+
+	var _fsUpdateDoc2 = __webpack_require__(20);
+
+	var _fsUpdateDoc3 = _interopRequireDefault(_fsUpdateDoc2);
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+	//firestore
 	module.exports = function () {
 	  function init(db) {
 	    return function () {
-	      var firebaseRefs = new Map();
-	      var firebaseListeners = new Map();
+	      var refs = new Map();
+	      var listeners = new Map();
 	      var syncs = new WeakMap();
 
-	      return {
-	        initializedApp: db.app,
-	        listenTo: function listenTo(endpoint, options) {
-	          return _bind3.default.call(this, endpoint, options, 'listenTo', {
-	            db: db,
-	            refs: firebaseRefs,
-	            listeners: firebaseListeners,
-	            syncs: syncs
-	          });
-	        },
-	        bindToState: function bindToState(endpoint, options) {
-	          return _bind3.default.call(this, endpoint, options, 'bindToState', {
-	            db: db,
-	            refs: firebaseRefs,
-	            listeners: firebaseListeners
-	          });
-	        },
-	        syncState: function syncState(endpoint, options) {
-	          return _sync3.default.call(this, endpoint, options, {
-	            db: db,
-	            refs: firebaseRefs,
-	            listeners: firebaseListeners,
-	            syncs: syncs
-	          });
-	        },
-	        fetch: function fetch(endpoint, options) {
-	          return (0, _fetch3.default)(endpoint, options, db);
-	        },
-	        post: function post(endpoint, options) {
-	          return (0, _post3.default)(endpoint, options, db);
-	        },
-	        update: function update(endpoint, options) {
-	          return (0, _update3.default)(endpoint, options, {
-	            db: db
-	          });
-	        },
-	        push: function push(endpoint, options) {
-	          return (0, _push3.default)(endpoint, options, db);
-	        },
-	        removeBinding: function removeBinding(binding) {
-	          (0, _removeBinding3.default)(binding, {
-	            refs: firebaseRefs,
-	            listeners: firebaseListeners,
-	            syncs: syncs
-	          });
-	        },
-	        remove: function remove(endpoint, fn) {
-	          return (0, _remove3.default)(endpoint, db, fn);
-	        },
-	        reset: function reset() {
-	          return (0, _reset3.default)({
-	            refs: firebaseRefs,
-	            listeners: firebaseListeners,
-	            syncs: syncs
-	          });
-	        }
-	      };
+	      if (typeof db.ref === 'function') {
+	        var rebase = {
+	          initializedApp: db.app,
+	          listenTo: function listenTo(endpoint, options) {
+	            return _bind3.default.call(this, endpoint, options, 'listenTo', {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          },
+	          bindToState: function bindToState(endpoint, options) {
+	            return _bind3.default.call(this, endpoint, options, 'bindToState', {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners
+	            });
+	          },
+	          syncState: function syncState(endpoint, options) {
+	            return _sync3.default.call(this, endpoint, options, {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          },
+	          fetch: function fetch(endpoint, options) {
+	            return (0, _fetch3.default)(endpoint, options, db);
+	          },
+	          post: function post(endpoint, options) {
+	            return (0, _post3.default)(endpoint, options, db);
+	          },
+	          update: function update(endpoint, options) {
+	            return (0, _update3.default)(endpoint, options, { db: db });
+	          },
+	          push: function push(endpoint, options) {
+	            return (0, _push3.default)(endpoint, options, db);
+	          },
+	          removeBinding: function removeBinding(binding) {
+	            (0, _removeBinding3.default)(binding, {
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          },
+	          remove: function remove(endpoint, fn) {
+	            return (0, _remove3.default)(endpoint, db, fn);
+	          },
+	          reset: function reset() {
+	            return (0, _reset3.default)({
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          }
+	        };
+	      } else {
+	        var rebase = {
+	          initializedApp: db.app,
+	          bindDoc: function bindDoc(path, options) {
+	            return _fsBind3.default.call(this, path, options, 'bindDoc', {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners
+	            });
+	          },
+	          bindCollection: function bindCollection(path, options) {
+	            return _fsBind3.default.call(this, path, options, 'bindCollection', {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners
+	            });
+	          },
+	          syncDoc: function syncDoc(doc, options) {
+	            return _fsSync3.default.call(this, doc, options, {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          },
+	          listenToDoc: function listenToDoc(doc, options) {
+	            return _fsBind3.default.call(this, doc, options, 'listenToDoc', {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners
+	            });
+	          },
+	          listenToCollection: function listenToCollection(path, options) {
+	            return _fsBind3.default.call(this, path, options, 'listenToCollection', {
+	              db: db,
+	              refs: refs,
+	              listeners: listeners
+	            });
+	          },
+	          addToCollection: function addToCollection(path, doc, key) {
+	            return _fsAddToCollection3.default.call(this, path, doc, db, key);
+	          },
+	          updateDoc: function updateDoc(path, doc, options) {
+	            return _fsUpdateDoc3.default.call(this, path, doc, db);
+	          },
+	          get: function get(path, options) {
+	            return _fsGet3.default.call(this, path, options, db);
+	          },
+	          removeDoc: function removeDoc(path) {
+	            return (0, _fsRemoveDoc3.default)(path, db);
+	          },
+	          removeFromCollection: function removeFromCollection(path, options) {
+	            return (0, _fsRemoveFromCollection3.default)(path, db, options);
+	          },
+	          removeBinding: function removeBinding(binding) {
+	            (0, _fsRemoveBinding3.default)(binding, {
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          },
+	          reset: function reset() {
+	            return (0, _reset3.default)({
+	              refs: refs,
+	              listeners: listeners,
+	              syncs: syncs
+	            });
+	          }
+	        };
+	      }
+	      return rebase;
 	    }();
 	  }
 
@@ -192,13 +295,17 @@ return /******/ (function(modules) { // webpackBootstrap
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	exports._setData = exports._handleError = exports._createNestedObject = exports._setUnmountHandler = exports._addListener = exports._updateSyncState = exports._firebaseRefsMixin = exports._addSync = exports._hasOwnNestedProperty = exports._getNestedObject = exports._isNestedPath = exports._isObject = exports._isValid = exports._toArray = exports._prepareData = exports._throwError = exports._setState = exports._returnRef = exports._addQueries = exports._createHash = undefined;
+	exports._fsSetUnmountHandler = exports._setData = exports._handleError = exports._createNestedObject = exports._setUnmountHandler = exports._addFirestoreListener = exports._addListener = exports._fsUpdateSyncState = exports._updateSyncState = exports._firebaseRefsMixin = exports._addSync = exports._hasOwnNestedProperty = exports._getNestedObject = exports._isNestedPath = exports._isObject = exports._isValid = exports._toArray = exports._fsPrepareData = exports._prepareData = exports._throwError = exports._setState = exports._returnRef = exports._addFirestoreQuery = exports._addQueries = exports._getSegmentCount = exports._createHash = undefined;
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 	var _removeBinding2 = __webpack_require__(3);
 
 	var _removeBinding3 = _interopRequireDefault(_removeBinding2);
+
+	var _fsRemoveBinding2 = __webpack_require__(4);
+
+	var _fsRemoveBinding3 = _interopRequireDefault(_fsRemoveBinding2);
 
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -355,9 +462,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return ref;
 	};
 
+	var _addFirestoreQuery = function _addFirestoreQuery(ref, query) {
+	  if (query) {
+	    return query(ref);
+	  }
+	  return ref;
+	};
+
 	var _createHash = function _createHash(endpoint, invoker) {
 	  var hash = 0;
-	  var str = endpoint + invoker + Date.now();
+	  var str = endpoint + invoker + Math.random();
 	  if (str.length == 0) return hash;
 	  for (var i = 0; i < str.length; i++) {
 	    var char = str.charCodeAt(i);
@@ -380,6 +494,19 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _setUnmountHandler = function _setUnmountHandler(context, id, refs, listeners, syncs) {
 	  var removeListeners = function removeListeners() {
 	    (0, _removeBinding3.default)({ context: context, id: id }, { refs: refs, listeners: listeners, syncs: syncs });
+	  };
+	  if (typeof context.componentWillUnmount === 'function') {
+	    var unmount = context.componentWillUnmount;
+	  }
+	  context.componentWillUnmount = function () {
+	    removeListeners();
+	    if (unmount) unmount.call(context);
+	  };
+	};
+
+	var _fsSetUnmountHandler = function _fsSetUnmountHandler(context, id, refs, listeners, syncs) {
+	  var removeListeners = function removeListeners() {
+	    (0, _fsRemoveBinding3.default)({ context: context, id: id }, { refs: refs, listeners: listeners, syncs: syncs });
 	  };
 	  if (typeof context.componentWillUnmount === 'function') {
 	    var unmount = context.componentWillUnmount;
@@ -420,6 +547,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
+	var _fsUpdateSyncState = function _fsUpdateSyncState(ref, data) {
+	  ref.set(data);
+	};
+
 	var _addListener = function _addListener(id, invoker, options, ref, listeners) {
 	  ref = _addQueries(ref, options.queries);
 	  var boundOnFailure = typeof options.onFailure === 'function' ? options.onFailure.bind(options.context) : null;
@@ -452,12 +583,85 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, boundOnFailure));
 	};
 
+	var _addFirestoreListener = function _addFirestoreListener(id, invoker, options, ref, listeners) {
+	  ref = _addFirestoreQuery(ref, options.query);
+	  var boundOnFailure = typeof options.onFailure === 'function' ? options.onFailure.bind(options.context) : undefined;
+	  listeners.set(id, ref.onSnapshot(function (snapshot) {
+	    if (invoker.match(/^listenTo/)) {
+	      if (invoker === 'listenToDoc') {
+	        if (snapshot.exists) {
+	          var newState = _fsPrepareData(snapshot, options);
+	          return options.then.call(options.context, newState);
+	        }
+	      }
+	      if (invoker === 'listenToCollection') {
+	        if (!snapshot.empty) {
+	          var _newState2 = _fsPrepareData(snapshot, options, true);
+	          return options.then.call(options.context, _newState2);
+	        }
+	      }
+	    } else {
+	      if (invoker === 'syncDoc') {
+	        if (snapshot.exists) {
+	          var _newState3 = _fsPrepareData(snapshot, options);
+	          options.reactSetState.call(options.context, function (currentState) {
+	            return Object.assign(currentState, _newState3);
+	          });
+	        }
+	      } else if (invoker === 'bindDoc') {
+	        if (snapshot.exists) {
+	          var _newState4 = _fsPrepareData(snapshot, options);
+	          _setState.call(options.context, function (currentState) {
+	            return Object.assign(currentState, _newState4);
+	          });
+	        }
+	      } else if (invoker === 'bindCollection') {
+	        if (!snapshot.empty) {
+	          var _newState5 = _fsPrepareData(snapshot, options, true);
+	          _setState.call(options.context, function (currentState) {
+	            return Object.assign(currentState, _newState5);
+	          });
+	        }
+	      }
+	      if (options.then && options.then.called === false) {
+	        options.then.call(options.context);
+	        options.then.called = true;
+	      }
+	    }
+	  }, boundOnFailure));
+	};
+
+	var _getSegmentCount = function _getSegmentCount(path) {
+	  return path.match(/^\//) ? path.split('/').slice(1).length : path.split('/').length;
+	};
+
+	var _fsPrepareData = function _fsPrepareData(snapshot, options) {
+	  var isCollection = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+
+	  var meta = {};
+	  if (!isCollection) {
+	    if (options.withRefs) meta.ref = snapshot.ref;
+	    if (options.withIds) meta.id = snapshot.id;
+	    return options.state ? _defineProperty({}, options.state, Object.assign({}, snapshot.data(), meta)) : Object.assign({}, snapshot.data(), meta);
+	  }
+	  var collection = [];
+	  snapshot.forEach(function (doc) {
+	    if (options.withRefs) meta.ref = doc.ref;
+	    if (options.withIds) meta.id = doc.id;
+	    collection.push(Object.assign({}, doc.data(), meta));
+	  });
+	  return options.state ? _defineProperty({}, options.state, collection) : collection;
+	};
+
 	exports._createHash = _createHash;
+	exports._getSegmentCount = _getSegmentCount;
 	exports._addQueries = _addQueries;
+	exports._addFirestoreQuery = _addFirestoreQuery;
 	exports._returnRef = _returnRef;
 	exports._setState = _setState;
 	exports._throwError = _throwError;
 	exports._prepareData = _prepareData;
+	exports._fsPrepareData = _fsPrepareData;
 	exports._toArray = _toArray;
 	exports._isValid = _isValid;
 	exports._isObject = _isObject;
@@ -467,11 +671,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports._addSync = _addSync;
 	exports._firebaseRefsMixin = _firebaseRefsMixin;
 	exports._updateSyncState = _updateSyncState;
+	exports._fsUpdateSyncState = _fsUpdateSyncState;
 	exports._addListener = _addListener;
+	exports._addFirestoreListener = _addFirestoreListener;
 	exports._setUnmountHandler = _setUnmountHandler;
 	exports._createNestedObject = _createNestedObject;
 	exports._handleError = _handleError;
 	exports._setData = _setData;
+	exports._fsSetUnmountHandler = _fsSetUnmountHandler;
 
 /***/ }),
 /* 3 */
@@ -516,6 +723,43 @@ return /******/ (function(modules) { // webpackBootstrap
 
 /***/ }),
 /* 4 */
+/***/ (function(module, exports) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsRemoveBinding;
+	function _fsRemoveBinding(_ref, _ref2) {
+	  var id = _ref.id,
+	      context = _ref.context;
+	  var refs = _ref2.refs,
+	      listeners = _ref2.listeners,
+	      syncs = _ref2.syncs;
+
+	  var unsubscribe = listeners.get(id);
+	  if (typeof unsubscribe === 'function') {
+	    unsubscribe();
+	    refs.delete(id);
+	    listeners.delete(id);
+	    if (syncs) {
+	      var currentSyncs = syncs.get(context);
+	      if (currentSyncs && currentSyncs.length > 0) {
+	        var idx = currentSyncs.findIndex(function (item, index) {
+	          return item.id === id;
+	        });
+	        if (idx !== -1) {
+	          currentSyncs.splice(idx, 1);
+	          syncs.set(context, currentSyncs);
+	        }
+	      }
+	    }
+	  }
+	}
+
+/***/ }),
+/* 5 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -523,7 +767,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	exports._validateEndpoint = exports._validateDatabase = exports.optionValidators = undefined;
+	exports._validateCollectionPath = exports._validateDocumentPath = exports._validateEndpoint = exports._validateDatabase = exports.optionValidators = undefined;
 
 	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -603,8 +847,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _validateDatabase = function _validateDatabase(db) {
 	  var defaultError = 'Rebase.createClass failed.';
 	  var errorMsg;
-	  if ((typeof db === 'undefined' ? 'undefined' : _typeof(db)) !== 'object' || !db.ref) {
-	    errorMsg = defaultError + ' Expected an initialized firebase database object.';
+	  if ((typeof db === 'undefined' ? 'undefined' : _typeof(db)) !== 'object' || !db.ref && !db.collection) {
+	    errorMsg = defaultError + ' Expected an initialized firebase or firestore database object.';
 	  } else if (!db || arguments.length > 1) {
 	    errorMsg = defaultError + ' expects 1 argument.';
 	  }
@@ -614,12 +858,28 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
+	var _validateDocumentPath = function _validateDocumentPath(path) {
+	  var defaultError = 'Invalid document path.';
+	  if (typeof path !== 'string') (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
+	  var segmentCount = (0, _utils._getSegmentCount)(path);
+	  if (segmentCount % 2 !== 0) (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
+	};
+
+	var _validateCollectionPath = function _validateCollectionPath(path) {
+	  var defaultError = 'Invalid collection path.';
+	  if (typeof path !== 'string') (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
+	  var segmentCount = (0, _utils._getSegmentCount)(path);
+	  if (segmentCount % 2 === 0) (0, _utils._throwError)(defaultError, 'INVALID_ENDPOINT');
+	};
+
 	exports.optionValidators = optionValidators;
 	exports._validateDatabase = _validateDatabase;
 	exports._validateEndpoint = _validateEndpoint;
+	exports._validateDocumentPath = _validateDocumentPath;
+	exports._validateCollectionPath = _validateCollectionPath;
 
 /***/ }),
-/* 5 */
+/* 6 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -629,7 +889,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = _push;
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
 	function _push(endpoint, options, db) {
 	  (0, _validators._validateEndpoint)(endpoint);
@@ -645,7 +905,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 6 */
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -655,7 +915,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = _fetch;
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
 	var _utils = __webpack_require__(2);
 
@@ -682,7 +942,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 7 */
+/* 8 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -692,7 +952,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = _post;
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
 	function _post(endpoint, options, db) {
 	  (0, _validators._validateEndpoint)(endpoint);
@@ -706,7 +966,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 8 */
+/* 9 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -716,7 +976,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = _sync;
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
 	var _utils = __webpack_require__(2);
 
@@ -808,7 +1068,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 9 */
+/* 10 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -818,7 +1078,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = _bind;
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
 	var _utils = __webpack_require__(2);
 
@@ -840,7 +1100,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 10 */
+/* 11 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -850,7 +1110,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	});
 	exports.default = _update;
 
-	var _validators = __webpack_require__(4);
+	var _validators = __webpack_require__(5);
 
 	function _update(endpoint, options, state) {
 	  (0, _validators._validateEndpoint)(endpoint);
@@ -864,7 +1124,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 11 */
+/* 12 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -884,7 +1144,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}
 
 /***/ }),
-/* 12 */
+/* 13 */
 /***/ (function(module, exports) {
 
 	"use strict";
@@ -896,6 +1156,267 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.default = function (endpoint, db, fn) {
 	  return db.ref().child(endpoint).remove(fn);
 	};
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsSync;
+
+	var _validators = __webpack_require__(5);
+
+	var _utils = __webpack_require__(2);
+
+	function _fsSync(document, options, state) {
+	  //validate arguments
+	  (0, _validators._validateDocumentPath)(document);
+	  _validators.optionValidators.context(options);
+	  _validators.optionValidators.state(options);
+	  options.then && (options.then.called = false);
+	  //store reference to react's setState
+	  if (_fsSync.called !== true) {
+	    _fsSync.reactSetState = options.context.setState;
+	    _fsSync.called = true;
+	  }
+	  options.reactSetState = _fsSync.reactSetState;
+
+	  var id = (0, _utils._createHash)(document, 'syncDoc');
+	  var ref = state.db.doc(document);
+	  (0, _utils._firebaseRefsMixin)(id, ref, state.refs);
+	  (0, _utils._addFirestoreListener)(id, 'syncDoc', options, ref, state.listeners);
+	  (0, _utils._fsSetUnmountHandler)(options.context, id, state.refs, state.listeners, state.syncs);
+	  var sync = {
+	    id: id,
+	    updateFirebase: _utils._fsUpdateSyncState.bind(null, ref),
+	    stateKey: options.state
+	  };
+	  (0, _utils._addSync)(options.context, sync, state.syncs);
+	  options.context.setState = function (data, cb) {
+	    //if setState is a function, call it first before syncing to fb
+	    if (typeof data === 'function') {
+	      return _fsSync.reactSetState.call(options.context, data, function () {
+	        if (cb) cb.call(options.context);
+	        return options.context.setState.call(options.context, options.context.state);
+	      });
+	    }
+	    //if callback is supplied, call setState first before syncing to fb
+	    if (typeof cb === 'function') {
+	      return _fsSync.reactSetState.call(options.context, data, function () {
+	        cb();
+	        return options.context.setState.call(options.context, data);
+	      });
+	    }
+	    var syncsToCall = state.syncs.get(this);
+	    //if sync does not exist, call original Component.setState
+	    if (!syncsToCall || syncsToCall.length === 0) {
+	      return _fsSync.reactSetState.call(this, data, cb);
+	    }
+	    //send the update of synced keys to firestore
+	    var syncedKeys = syncsToCall.map(function (sync) {
+	      return {
+	        key: sync.stateKey,
+	        update: sync.updateFirebase
+	      };
+	    });
+	    syncedKeys.forEach(function (syncedKey) {
+	      if (data[syncedKey.key]) {
+	        syncedKey.update(data[syncedKey.key]);
+	      }
+	    });
+	    //send the update of all other keys through setState
+	    var allKeys = Object.keys(data);
+	    allKeys.forEach(function (key) {
+	      var absent = !syncedKeys.find(function (syncedKey) {
+	        return syncedKey.key === key;
+	      });
+	      if (absent) {
+	        var update = {};
+	        update[key] = data[key];
+	        _fsSync.reactSetState.call(options.context, function (currentState) {
+	          return Object.assign(currentState, update);
+	        }, cb);
+	      }
+	    });
+	  };
+	  return (0, _utils._returnRef)(document, 'syncDoc', id, options.context);
+	}
+
+/***/ }),
+/* 15 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsBind;
+
+	var _validators = __webpack_require__(5);
+
+	var _utils = __webpack_require__(2);
+
+	function _fsBind(path, options, invoker, state) {
+	  _validators.optionValidators.context(options);
+	  if (invoker === 'bindDoc') {
+	    (0, _validators._validateDocumentPath)(path);
+	  }
+	  if (invoker === 'bindCollection') {
+	    _validators.optionValidators.state(options);
+	    (0, _validators._validateCollectionPath)(path);
+	  }
+	  if (invoker === 'listenToDoc') {
+	    (0, _validators._validateDocumentPath)(path);
+	    _validators.optionValidators.then(options);
+	  }
+	  if (invoker === 'listenToCollection') {
+	    (0, _validators._validateCollectionPath)(path);
+	    _validators.optionValidators.then(options);
+	  }
+
+	  options.then && (options.then.called = false);
+
+	  var id = (0, _utils._createHash)(path, invoker);
+	  var segmentCount = (0, _utils._getSegmentCount)(path);
+	  var ref;
+	  if (segmentCount % 2 === 0) {
+	    ref = state.db.doc(path);
+	  } else {
+	    ref = state.db.collection(path);
+	  }
+	  (0, _utils._firebaseRefsMixin)(id, ref, state.refs);
+	  (0, _utils._addFirestoreListener)(id, invoker, options, ref, state.listeners);
+	  (0, _utils._fsSetUnmountHandler)(options.context, id, state.refs, state.listeners, state.syncs);
+	  return (0, _utils._returnRef)(path, invoker, id, options.context);
+	}
+
+/***/ }),
+/* 16 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsGet;
+
+	var _utils = __webpack_require__(2);
+
+	var _validators = __webpack_require__(5);
+
+	function _fsGet(endpoint) {
+	  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+	  var db = arguments[2];
+
+	  (0, _validators._validateEndpoint)(endpoint);
+	  var segmentCount = (0, _utils._getSegmentCount)(endpoint);
+	  var isCollection = segmentCount % 2 !== 0;
+	  var ref;
+	  if (isCollection) {
+	    ref = db.collection(endpoint);
+	    ref = (0, _utils._addFirestoreQuery)(ref, options.query);
+	  } else {
+	    ref = db.doc(endpoint);
+	  }
+	  return ref.get().then(function (snapshot) {
+	    if (isCollection && !snapshot.empty || !isCollection && snapshot.exists) {
+	      return (0, _utils._fsPrepareData)(snapshot, options, isCollection);
+	    } else {
+	      return Promise.reject(new Error('No Result'));
+	    }
+	  });
+	}
+
+/***/ }),
+/* 17 */
+/***/ (function(module, exports) {
+
+	"use strict";
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsRemoveDoc;
+	function _fsRemoveDoc(path, db) {
+	  return db.doc(path).delete();
+	}
+
+/***/ }),
+/* 18 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsAddToCollection;
+
+	var _validators = __webpack_require__(5);
+
+	function _fsAddToCollection(path, doc, db, key) {
+	  (0, _validators._validateCollectionPath)(path);
+	  if (key) {
+	    return db.collection(path).doc(key).set(doc);
+	  }
+	  return db.collection(path).add(doc);
+	}
+
+/***/ }),
+/* 19 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsRemoveFromCollection;
+
+	var _validators = __webpack_require__(5);
+
+	var _utils = __webpack_require__(2);
+
+	function _fsRemoveFromCollection(path, db) {
+	  var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
+	  (0, _validators._validateCollectionPath)(path);
+	  var ref = db.collection(path);
+	  ref = (0, _utils._addFirestoreQuery)(ref, options.query);
+	  return ref.get().then(function (snapshot) {
+	    if (!snapshot.empty) {
+	      var batch = db.batch();
+	      snapshot.forEach(function (doc) {
+	        batch.delete(doc.ref);
+	      });
+	      return batch.commit();
+	    }
+	  });
+	}
+
+/***/ }),
+/* 20 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsUpdateDoc;
+
+	var _validators = __webpack_require__(5);
+
+	function _fsUpdateDoc(document, data, db) {
+	  (0, _validators._validateDocumentPath)(document);
+	  return db.doc(document).update(data);
+	}
 
 /***/ })
 /******/ ])

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -135,9 +135,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _fsUpdateDoc3 = _interopRequireDefault(_fsUpdateDoc2);
 
+	var _fsReset2 = __webpack_require__(21);
+
+	var _fsReset3 = _interopRequireDefault(_fsReset2);
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	//firestore
+	//database
+	//helpers
 	module.exports = function () {
 	  function init(db) {
 	    return function () {
@@ -263,7 +268,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            });
 	          },
 	          reset: function reset() {
-	            return (0, _reset3.default)({
+	            return (0, _fsReset3.default)({
 	              refs: refs,
 	              listeners: listeners,
 	              syncs: syncs
@@ -283,8 +288,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 	}();
 
-	//database
-	//helpers
+	//firestore
 
 /***/ }),
 /* 2 */
@@ -451,6 +455,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  };
 
 	  for (var key in queries) {
+	    /* istanbul ignore else */
 	    if (queries.hasOwnProperty(key)) {
 	      if (needArgs[key]) {
 	        ref = ref[key](queries[key]);
@@ -711,6 +716,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var idx = currentSyncs.findIndex(function (item, index) {
 	          return item.id === id;
 	        });
+	        /*istanbul ignore else */
 	        if (idx !== -1) {
 	          currentSyncs.splice(idx, 1);
 	          syncs.set(context, currentSyncs);
@@ -748,6 +754,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var idx = currentSyncs.findIndex(function (item, index) {
 	          return item.id === id;
 	        });
+	        /*istanbul ignore else */
 	        if (idx !== -1) {
 	          currentSyncs.splice(idx, 1);
 	          syncs.set(context, currentSyncs);
@@ -848,10 +855,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var errorMsg;
 	  if ((typeof db === 'undefined' ? 'undefined' : _typeof(db)) !== 'object' || !db.ref && !db.collection) {
 	    errorMsg = defaultError + ' Expected an initialized firebase or firestore database object.';
-	  } else if (!db || arguments.length > 1) {
-	    errorMsg = defaultError + ' expects 1 argument.';
 	  }
-
 	  if (typeof errorMsg !== 'undefined') {
 	    (0, _utils._throwError)(errorMsg, 'INVALID_CONFIG');
 	  }
@@ -986,7 +990,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  _validators.optionValidators.defaultValue(options);
 	  options.queries && _validators.optionValidators.query(options);
 	  options.then && (options.then.called = false);
-	  options.onFailure = options.onFailure ? options.onFailure.bind(options.context) : function () {};
+	  options.onFailure = options.onFailure ? options.onFailure.bind(options.context) : null;
 	  options.keepKeys = options.keepKeys && options.asArray;
 
 	  //store reference to react's setState
@@ -1415,6 +1419,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	function _fsUpdateDoc(document, data, db) {
 	  (0, _validators._validateDocumentPath)(document);
 	  return db.doc(document).update(data);
+	}
+
+/***/ }),
+/* 21 */
+/***/ (function(module, exports) {
+
+	"use strict";
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports.default = _fsReset;
+	function _fsReset(state) {
+	  state.listeners.forEach(function (unsubscribe, id) {
+	    unsubscribe();
+	  });
+	  state.listeners = new Map();
+	  state.refs = new Map();
+	  state.syncs = new WeakMap();
+	  return null;
 	}
 
 /***/ })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "re-base",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1321,9 +1321,9 @@
       "dev": true
     },
     "coveralls": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
       "requires": {
         "js-yaml": "3.6.1",
@@ -1988,10 +1988,11 @@
       }
     },
     "firebase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.4.0.tgz",
-      "integrity": "sha1-z/o0lkw4riQVfskw2+FHgW/Y4/Q=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-4.5.0.tgz",
+      "integrity": "sha1-4Jc6mAO3TEydc9Gfh0cS5unRa6c=",
       "requires": {
+        "@firebase/webchannel-wrapper": "0.2.1",
         "dom-storage": "2.0.2",
         "faye-websocket": "0.9.3",
         "jsonwebtoken": "7.4.3",
@@ -1999,6 +2000,11 @@
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
+        "@firebase/webchannel-wrapper": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.1.tgz",
+          "integrity": "sha512-5y9ghXy8ztIaI9X/howqHv4FWI5I+OlNr+i+q3213gk5PwFzqHwbsh9jKV6134VkwJV+U1D0VERhsXUpHeZnWA=="
+        },
         "base64url": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
@@ -2037,9 +2043,9 @@
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-parser-js": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.6.tgz",
-          "integrity": "sha1-GVJz9YcExFLWcQdr4gEyndNB3FU="
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.8.tgz",
+          "integrity": "sha512-jmHp99g6/fLx0pRNJqzsQgjsclCHAY7NhIeA3/U+bsGNvgbvUCQFQY9m5AYpqpAxY/2VcikfbKpjQozSTiz0jA=="
         },
         "isemail": {
           "version": "1.2.0",
@@ -2128,7 +2134,7 @@
           "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
           "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
           "requires": {
-            "http-parser-js": "0.4.6",
+            "http-parser-js": "0.4.8",
             "websocket-extensions": "0.1.2"
           }
         },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "author": "Tyler McGinnis and Jacob Turner",
   "dependencies": {
-    "firebase": "^4.0.0"
+    "firebase": "^4.5.0"
   },
   "devDependencies": {
     "babel-core": "^6.18.0",
@@ -17,7 +17,7 @@
     "babel-plugin-istanbul": "^4.1.1",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "coveralls": "^2.11.14",
+    "coveralls": "^2.13.3",
     "cross-env": "^4.0.0",
     "jasmine-core": "^2.5.2",
     "karma": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "re-base",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "A Relay inspired library for building React.js + Firebase applications.",
   "main": "index.js",
   "repository": {

--- a/src/lib/fsAddToCollection.js
+++ b/src/lib/fsAddToCollection.js
@@ -1,12 +1,11 @@
 import { _validateCollectionPath } from './validators';
+import { _fsCreateRef } from './utils';
 
 export default function _fsAddToCollection(path, doc, db, key) {
   _validateCollectionPath(path);
+  const ref = _fsCreateRef(path, db);
   if (key) {
-    return db
-      .collection(path)
-      .doc(key)
-      .set(doc);
+    return ref.doc(key).set(doc);
   }
-  return db.collection(path).add(doc);
+  return ref.add(doc);
 }

--- a/src/lib/fsAddToCollection.js
+++ b/src/lib/fsAddToCollection.js
@@ -1,0 +1,12 @@
+import { _validateCollectionPath } from './validators';
+
+export default function _fsAddToCollection(path, doc, db, key) {
+  _validateCollectionPath(path);
+  if (key) {
+    return db
+      .collection(path)
+      .doc(key)
+      .set(doc);
+  }
+  return db.collection(path).add(doc);
+}

--- a/src/lib/fsBind.js
+++ b/src/lib/fsBind.js
@@ -21,7 +21,10 @@ export default function _fsBind(path, options, invoker, state) {
     optionValidators.state(options);
     _validateCollectionPath(path);
   }
-  invoker === 'listen' && optionValidators.then(options);
+  if (invoker === 'listenToDoc') {
+    _validateDocumentPath(path);
+    optionValidators.then(options);
+  }
 
   options.then && (options.then.called = false);
 

--- a/src/lib/fsBind.js
+++ b/src/lib/fsBind.js
@@ -25,6 +25,10 @@ export default function _fsBind(path, options, invoker, state) {
     _validateDocumentPath(path);
     optionValidators.then(options);
   }
+  if (invoker === 'listenToCollection') {
+    _validateCollectionPath(path);
+    optionValidators.then(options);
+  }
 
   options.then && (options.then.called = false);
 

--- a/src/lib/fsBind.js
+++ b/src/lib/fsBind.js
@@ -1,4 +1,8 @@
-import { optionValidators, _validateDocumentPath } from './validators';
+import {
+  optionValidators,
+  _validateDocumentPath,
+  _validateCollectionPath
+} from './validators';
 import {
   _createHash,
   _returnRef,
@@ -9,14 +13,16 @@ import {
 } from './utils';
 
 export default function _fsBind(path, options, invoker, state) {
-  _validateDocumentPath(path);
   optionValidators.context(options);
-  invoker === 'listen' && optionValidators.then(options);
   if (invoker === 'bindDoc') {
-    optionValidators.state(options);
     _validateDocumentPath(path);
   }
-  options.queries && optionValidators.query(options);
+  if (invoker === 'bindCollection') {
+    optionValidators.state(options);
+    _validateCollectionPath(path);
+  }
+  invoker === 'listen' && optionValidators.then(options);
+
   options.then && (options.then.called = false);
 
   var id = _createHash(path, invoker);

--- a/src/lib/fsBind.js
+++ b/src/lib/fsBind.js
@@ -1,0 +1,40 @@
+import { optionValidators, _validateDocumentPath } from './validators';
+import {
+  _createHash,
+  _returnRef,
+  _firebaseRefsMixin,
+  _addFirestoreListener,
+  _fsSetUnmountHandler,
+  _getSegmentCount
+} from './utils';
+
+export default function _fsBind(path, options, invoker, state) {
+  _validateDocumentPath(path);
+  optionValidators.context(options);
+  invoker === 'listen' && optionValidators.then(options);
+  if (invoker === 'bindDoc') {
+    optionValidators.state(options);
+    _validateDocumentPath(path);
+  }
+  options.queries && optionValidators.query(options);
+  options.then && (options.then.called = false);
+
+  var id = _createHash(path, invoker);
+  const segmentCount = _getSegmentCount(path);
+  var ref;
+  if (segmentCount % 2 === 0) {
+    ref = state.db.doc(path);
+  } else {
+    ref = state.db.collection(path);
+  }
+  _firebaseRefsMixin(id, ref, state.refs);
+  _addFirestoreListener(id, invoker, options, ref, state.listeners);
+  _fsSetUnmountHandler(
+    options.context,
+    id,
+    state.refs,
+    state.listeners,
+    state.syncs
+  );
+  return _returnRef(path, invoker, id, options.context);
+}

--- a/src/lib/fsBind.js
+++ b/src/lib/fsBind.js
@@ -9,11 +9,12 @@ import {
   _firebaseRefsMixin,
   _addFirestoreListener,
   _fsSetUnmountHandler,
-  _getSegmentCount
+  _fsCreateRef
 } from './utils';
 
 export default function _fsBind(path, options, invoker, state) {
   optionValidators.context(options);
+  options.then && (options.then.called = false);
   if (invoker === 'bindDoc') {
     _validateDocumentPath(path);
   }
@@ -29,17 +30,8 @@ export default function _fsBind(path, options, invoker, state) {
     _validateCollectionPath(path);
     optionValidators.then(options);
   }
-
-  options.then && (options.then.called = false);
-
+  const ref = _fsCreateRef(path, state.db);
   var id = _createHash(path, invoker);
-  const segmentCount = _getSegmentCount(path);
-  var ref;
-  if (segmentCount % 2 === 0) {
-    ref = state.db.doc(path);
-  } else {
-    ref = state.db.collection(path);
-  }
   _firebaseRefsMixin(id, ref, state.refs);
   _addFirestoreListener(id, invoker, options, ref, state.listeners);
   _fsSetUnmountHandler(

--- a/src/lib/fsGet.js
+++ b/src/lib/fsGet.js
@@ -1,0 +1,25 @@
+import { _addFirestoreQuery, _fsPrepareData, _getSegmentCount } from './utils';
+import { _validateEndpoint } from './validators';
+
+export default function _fsGet(endpoint, options = {}, db) {
+  _validateEndpoint(endpoint);
+  const segmentCount = _getSegmentCount(endpoint);
+  const isCollection = segmentCount % 2 !== 0;
+  var ref;
+  if (isCollection) {
+    ref = db.collection(endpoint);
+    ref = _addFirestoreQuery(ref, options.query);
+  } else {
+    ref = db.doc(endpoint);
+  }
+  return ref.get().then(snapshot => {
+    if (
+      (isCollection && !snapshot.empty) ||
+      (!isCollection && snapshot.exists)
+    ) {
+      return _fsPrepareData(snapshot, options, isCollection);
+    } else {
+      return Promise.reject(new Error('No Result'));
+    }
+  });
+}

--- a/src/lib/fsGet.js
+++ b/src/lib/fsGet.js
@@ -1,17 +1,12 @@
-import { _addFirestoreQuery, _fsPrepareData, _getSegmentCount } from './utils';
+import { _addFirestoreQuery, _fsPrepareData, _fsCreateRef } from './utils';
 import { _validateEndpoint } from './validators';
 
 export default function _fsGet(endpoint, options = {}, db) {
   _validateEndpoint(endpoint);
-  const segmentCount = _getSegmentCount(endpoint);
-  const isCollection = segmentCount % 2 !== 0;
-  var ref;
-  if (isCollection) {
-    ref = db.collection(endpoint);
-    ref = _addFirestoreQuery(ref, options.query);
-  } else {
-    ref = db.doc(endpoint);
-  }
+  let ref = _fsCreateRef(endpoint, db);
+  //check if ref is a collection
+  const isCollection = !!ref.add;
+  ref = _addFirestoreQuery(ref, options.query);
   return ref.get().then(snapshot => {
     if (
       (isCollection && !snapshot.empty) ||

--- a/src/lib/fsRemoveBinding.js
+++ b/src/lib/fsRemoveBinding.js
@@ -1,0 +1,23 @@
+export default function _fsRemoveBinding(
+  { id, context },
+  { refs, listeners, syncs }
+) {
+  var unsubscribe = listeners.get(id);
+  if (typeof unsubscribe === 'function') {
+    unsubscribe();
+    refs.delete(id);
+    listeners.delete(id);
+    if (syncs) {
+      var currentSyncs = syncs.get(context);
+      if (currentSyncs && currentSyncs.length > 0) {
+        var idx = currentSyncs.findIndex((item, index) => {
+          return item.id === id;
+        });
+        if (idx !== -1) {
+          currentSyncs.splice(idx, 1);
+          syncs.set(context, currentSyncs);
+        }
+      }
+    }
+  }
+}

--- a/src/lib/fsRemoveBinding.js
+++ b/src/lib/fsRemoveBinding.js
@@ -13,6 +13,7 @@ export default function _fsRemoveBinding(
         var idx = currentSyncs.findIndex((item, index) => {
           return item.id === id;
         });
+        /*istanbul ignore else */
         if (idx !== -1) {
           currentSyncs.splice(idx, 1);
           syncs.set(context, currentSyncs);

--- a/src/lib/fsRemoveDoc.js
+++ b/src/lib/fsRemoveDoc.js
@@ -1,3 +1,5 @@
+import { _fsCreateRef } from './utils';
 export default function _fsRemoveDoc(path, db) {
-  return db.doc(path).delete();
+  const ref = _fsCreateRef(path, db);
+  return ref.delete();
 }

--- a/src/lib/fsRemoveDoc.js
+++ b/src/lib/fsRemoveDoc.js
@@ -1,0 +1,3 @@
+export default function _fsRemoveDoc(path, db) {
+  return db.doc(path).delete();
+}

--- a/src/lib/fsRemoveFromCollection.js
+++ b/src/lib/fsRemoveFromCollection.js
@@ -1,9 +1,9 @@
 import { _validateCollectionPath } from './validators';
-import { _addFirestoreQuery } from './utils';
+import { _addFirestoreQuery, _fsCreateRef } from './utils';
 
 export default function _fsRemoveFromCollection(path, db, options = {}) {
   _validateCollectionPath(path);
-  let ref = db.collection(path);
+  let ref = _fsCreateRef(path, db);
   ref = _addFirestoreQuery(ref, options.query);
   return ref.get().then(snapshot => {
     if (!snapshot.empty) {

--- a/src/lib/fsRemoveFromCollection.js
+++ b/src/lib/fsRemoveFromCollection.js
@@ -1,0 +1,17 @@
+import { _validateCollectionPath } from './validators';
+import { _addFirestoreQuery } from './utils';
+
+export default function _fsRemoveFromCollection(path, db, options = {}) {
+  _validateCollectionPath(path);
+  let ref = db.collection(path);
+  ref = _addFirestoreQuery(ref, options.query);
+  return ref.get().then(snapshot => {
+    if (!snapshot.empty) {
+      const batch = db.batch();
+      snapshot.forEach(doc => {
+        batch.delete(doc.ref);
+      });
+      return batch.commit();
+    }
+  });
+}

--- a/src/lib/fsReset.js
+++ b/src/lib/fsReset.js
@@ -1,0 +1,9 @@
+export default function _fsReset(state) {
+  state.listeners.forEach((unsubscribe, id) => {
+    unsubscribe();
+  });
+  state.listeners = new Map();
+  state.refs = new Map();
+  state.syncs = new WeakMap();
+  return null;
+}

--- a/src/lib/fsSync.js
+++ b/src/lib/fsSync.js
@@ -8,9 +8,7 @@ import {
   _addSync,
   _addFirestoreListener,
   _fsUpdateSyncState,
-  _isNestedPath,
-  _getNestedObject,
-  _hasOwnNestedProperty
+  _fsCreateRef
 } from './utils';
 
 export default function _fsSync(document, options, state) {
@@ -27,7 +25,7 @@ export default function _fsSync(document, options, state) {
   options.reactSetState = _fsSync.reactSetState;
 
   const id = _createHash(document, 'syncDoc');
-  const ref = state.db.doc(document);
+  const ref = _fsCreateRef(document, state.db);
   _firebaseRefsMixin(id, ref, state.refs);
   _addFirestoreListener(id, 'syncDoc', options, ref, state.listeners);
   _fsSetUnmountHandler(

--- a/src/lib/fsSync.js
+++ b/src/lib/fsSync.js
@@ -1,0 +1,101 @@
+import { _validateDocumentPath, optionValidators } from './validators';
+import {
+  _returnRef,
+  _createHash,
+  _fsSetUnmountHandler,
+  _firebaseRefsMixin,
+  _addListener,
+  _addSync,
+  _addFirestoreListener,
+  _fsUpdateSyncState,
+  _isNestedPath,
+  _getNestedObject,
+  _hasOwnNestedProperty
+} from './utils';
+
+export default function _fsSync(document, options, state) {
+  //validate arguments
+  _validateDocumentPath(document);
+  optionValidators.context(options);
+  optionValidators.state(options);
+  options.then && (options.then.called = false);
+  //store reference to react's setState
+  if (_fsSync.called !== true) {
+    _fsSync.reactSetState = options.context.setState;
+    _fsSync.called = true;
+  }
+  options.reactSetState = _fsSync.reactSetState;
+
+  const id = _createHash(document, 'syncDoc');
+  const ref = state.db.doc(document);
+  _firebaseRefsMixin(id, ref, state.refs);
+  _addFirestoreListener(id, 'syncDoc', options, ref, state.listeners);
+  _fsSetUnmountHandler(
+    options.context,
+    id,
+    state.refs,
+    state.listeners,
+    state.syncs
+  );
+  var sync = {
+    id: id,
+    updateFirebase: _fsUpdateSyncState.bind(null, ref),
+    stateKey: options.state
+  };
+  _addSync(options.context, sync, state.syncs);
+  options.context.setState = function(data, cb) {
+    //if setState is a function, call it first before syncing to fb
+    if (typeof data === 'function') {
+      return _fsSync.reactSetState.call(options.context, data, () => {
+        if (cb) cb.call(options.context);
+        return options.context.setState.call(
+          options.context,
+          options.context.state
+        );
+      });
+    }
+    //if callback is supplied, call setState first before syncing to fb
+    if (typeof cb === 'function') {
+      return _fsSync.reactSetState.call(options.context, data, () => {
+        cb();
+        return options.context.setState.call(options.context, data);
+      });
+    }
+    var syncsToCall = state.syncs.get(this);
+    //if sync does not exist, call original Component.setState
+    if (!syncsToCall || syncsToCall.length === 0) {
+      return _fsSync.reactSetState.call(this, data, cb);
+    }
+    //send the update of synced keys to firestore
+    var syncedKeys = syncsToCall.map(sync => {
+      return {
+        key: sync.stateKey,
+        update: sync.updateFirebase
+      };
+    });
+    syncedKeys.forEach(syncedKey => {
+      if (data[syncedKey.key]) {
+        syncedKey.update(data[syncedKey.key]);
+      }
+    });
+    //send the update of all other keys through setState
+    var allKeys = Object.keys(data);
+    allKeys.forEach(key => {
+      var absent = !syncedKeys.find(syncedKey => {
+        return syncedKey.key === key;
+      });
+      if (absent) {
+        var update = {};
+        update[key] = data[key];
+        _fsSync.reactSetState.call(
+          options.context,
+          function(currentState) {
+            return Object.assign(currentState, update);
+          },
+          cb
+        );
+      }
+    });
+  };
+  return _returnRef(document, 'syncDoc', id, options.context);
+}

--- a/src/lib/fsUpdateDoc.js
+++ b/src/lib/fsUpdateDoc.js
@@ -1,6 +1,7 @@
 import { _validateDocumentPath } from './validators';
-
+import { _fsCreateRef } from './utils';
 export default function _fsUpdateDoc(document, data, db) {
   _validateDocumentPath(document);
-  return db.doc(document).update(data);
+  const ref = _fsCreateRef(document, db);
+  return ref.update(data);
 }

--- a/src/lib/fsUpdateDoc.js
+++ b/src/lib/fsUpdateDoc.js
@@ -1,0 +1,6 @@
+import { _validateDocumentPath } from './validators';
+
+export default function _fsUpdateDoc(document, data, db) {
+  _validateDocumentPath(document);
+  return db.doc(document).update(data);
+}

--- a/src/lib/removeBinding.js
+++ b/src/lib/removeBinding.js
@@ -16,6 +16,7 @@ export default function _removeBinding(
         var idx = currentSyncs.findIndex((item, index) => {
           return item.id === id;
         });
+        /*istanbul ignore else */
         if (idx !== -1) {
           currentSyncs.splice(idx, 1);
           syncs.set(context, currentSyncs);

--- a/src/lib/sync.js
+++ b/src/lib/sync.js
@@ -22,7 +22,7 @@ export default function _sync(endpoint, options, state) {
   options.then && (options.then.called = false);
   options.onFailure = options.onFailure
     ? options.onFailure.bind(options.context)
-    : () => {};
+    : null;
   options.keepKeys = options.keepKeys && options.asArray;
 
   //store reference to react's setState

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -300,14 +300,16 @@ const _getSegmentCount = function(path) {
 };
 
 const _fsPrepareData = function(snapshot, options, isCollection = false) {
+  let meta = {};
   if (!isCollection) {
+    if (options.withRefs) meta.ref = snapshot.ref;
+    if (options.withIds) meta.id = snapshot.id;
     return options.state
-      ? { [options.state]: snapshot.data() }
-      : snapshot.data();
+      ? { [options.state]: Object.assign({}, snapshot.data(), meta) }
+      : Object.assign({}, snapshot.data(), meta);
   }
   const collection = [];
   snapshot.forEach(doc => {
-    const meta = {};
     if (options.withRefs) meta.ref = doc.ref;
     if (options.withIds) meta.id = doc.id;
     collection.push(Object.assign({}, doc.data(), meta));

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -360,6 +360,7 @@ export {
   _isObject,
   _isNestedPath,
   _getNestedObject,
+  _getSegmentCount,
   _hasOwnNestedProperty,
   _addSync,
   _firebaseRefsMixin,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,5 @@
 import _removeBinding from './removeBinding';
+import _fsRemoveBinding from './fsRemoveBinding';
 
 const _isObject = function(obj) {
   return Object.prototype.toString.call(obj) === '[object Object]'
@@ -135,6 +136,19 @@ const _handleError = function(onFailure, err) {
 const _setUnmountHandler = function(context, id, refs, listeners, syncs) {
   var removeListeners = () => {
     _removeBinding({ context, id }, { refs, listeners, syncs });
+  };
+  if (typeof context.componentWillUnmount === 'function') {
+    var unmount = context.componentWillUnmount;
+  }
+  context.componentWillUnmount = function() {
+    removeListeners();
+    if (unmount) unmount.call(context);
+  };
+};
+
+const _fsSetUnmountHandler = function(context, id, refs, listeners, syncs) {
+  var removeListeners = () => {
+    _fsRemoveBinding({ context, id }, { refs, listeners, syncs });
   };
   if (typeof context.componentWillUnmount === 'function') {
     var unmount = context.componentWillUnmount;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -120,7 +120,7 @@ const _addFirestoreQuery = function(ref, query) {
 
 const _createHash = function(endpoint, invoker) {
   var hash = 0;
-  var str = endpoint + invoker + Date.now();
+  var str = endpoint + invoker + Math.random();
   if (str.length == 0) return hash;
   for (var i = 0; i < str.length; i++) {
     var char = str.charCodeAt(i);
@@ -271,7 +271,7 @@ const _addFirestoreListener = function _addFirestoreListener(
           }
         }
         if (invoker === 'listenToCollection') {
-          if (snapshot.exists) {
+          if (!snapshot.empty) {
             let newState = _fsPrepareData(snapshot, options, true);
             return options.then.call(options.context, newState);
           }
@@ -329,9 +329,7 @@ const _fsPrepareData = function(snapshot, options, isCollection = false) {
     if (options.withIds) meta.id = doc.id;
     collection.push(Object.assign({}, doc.data(), meta));
   });
-  return {
-    [options.state]: collection
-  };
+  return options.state ? { [options.state]: collection } : collection;
 };
 
 export {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -332,9 +332,22 @@ const _fsPrepareData = function(snapshot, options, isCollection = false) {
   return options.state ? { [options.state]: collection } : collection;
 };
 
+const _fsCreateRef = function(pathOrRef, db) {
+  if (typeof pathOrRef === 'object') {
+    return pathOrRef;
+  }
+  const segmentCount = _getSegmentCount(pathOrRef);
+  var ref;
+  if (segmentCount % 2 === 0) {
+    ref = db.doc(pathOrRef);
+  } else {
+    ref = db.collection(pathOrRef);
+  }
+  return ref;
+};
+
 export {
   _createHash,
-  _getSegmentCount,
   _addQueries,
   _addFirestoreQuery,
   _returnRef,
@@ -358,5 +371,6 @@ export {
   _createNestedObject,
   _handleError,
   _setData,
-  _fsSetUnmountHandler
+  _fsSetUnmountHandler,
+  _fsCreateRef
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -263,31 +263,46 @@ const _addFirestoreListener = function _addFirestoreListener(
   listeners.set(
     id,
     ref.onSnapshot(snapshot => {
-      if (invoker === 'syncDoc') {
-        if (snapshot.exists) {
-          let newState = _fsPrepareData(snapshot, options);
-          options.reactSetState.call(options.context, function(currentState) {
-            return Object.assign(currentState, newState);
-          });
+      if (invoker.match(/^listenTo/)) {
+        if (invoker === 'listenToDoc') {
+          if (snapshot.exists) {
+            let newState = _fsPrepareData(snapshot, options);
+            return options.then.call(options.context, newState);
+          }
         }
-      } else if (invoker === 'bindDoc') {
-        if (snapshot.exists) {
-          let newState = _fsPrepareData(snapshot, options);
-          _setState.call(options.context, function(currentState) {
-            return Object.assign(currentState, newState);
-          });
+        if (invoker === 'listenToCollection') {
+          if (snapshot.exists) {
+            let newState = _fsPrepareData(snapshot, options, true);
+            return options.then.call(options.context, newState);
+          }
         }
-      } else if (invoker === 'bindCollection') {
-        if (!snapshot.empty) {
-          let newState = _fsPrepareData(snapshot, options, true);
-          _setState.call(options.context, function(currentState) {
-            return Object.assign(currentState, newState);
-          });
+      } else {
+        if (invoker === 'syncDoc') {
+          if (snapshot.exists) {
+            let newState = _fsPrepareData(snapshot, options);
+            options.reactSetState.call(options.context, function(currentState) {
+              return Object.assign(currentState, newState);
+            });
+          }
+        } else if (invoker === 'bindDoc') {
+          if (snapshot.exists) {
+            let newState = _fsPrepareData(snapshot, options);
+            _setState.call(options.context, function(currentState) {
+              return Object.assign(currentState, newState);
+            });
+          }
+        } else if (invoker === 'bindCollection') {
+          if (!snapshot.empty) {
+            let newState = _fsPrepareData(snapshot, options, true);
+            _setState.call(options.context, function(currentState) {
+              return Object.assign(currentState, newState);
+            });
+          }
         }
-      }
-      if (options.then && options.then.called === false) {
-        options.then.call(options.context);
-        options.then.called = true;
+        if (options.then && options.then.called === false) {
+          options.then.call(options.context);
+          options.then.called = true;
+        }
       }
     }, boundOnFailure)
   );

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -100,6 +100,7 @@ const _addQueries = function(ref, queries) {
   };
 
   for (var key in queries) {
+    /* istanbul ignore else */
     if (queries.hasOwnProperty(key)) {
       if (needArgs[key]) {
         ref = ref[key](queries[key]);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -121,7 +121,6 @@ const _addFirestoreQuery = function(ref, query) {
 const _createHash = function(endpoint, invoker) {
   var hash = 0;
   var str = endpoint + invoker + Math.random();
-  if (str.length == 0) return hash;
   for (var i = 0; i < str.length; i++) {
     var char = str.charCodeAt(i);
     hash = (hash << 5) - hash + char;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -112,7 +112,10 @@ const _addQueries = function(ref, queries) {
 };
 
 const _addFirestoreQuery = function(ref, query) {
-  return query(ref);
+  if (query) {
+    return query(ref);
+  }
+  return ref;
 };
 
 const _createHash = function(endpoint, invoker) {
@@ -302,7 +305,7 @@ const _getSegmentCount = function(path) {
 };
 
 const _prepareNextState = function(snapshot, stateProp) {
-  return options.state ? { [options.state]: snapshot.data() } : snapshot.data();
+  return stateProp ? { [stateProp]: snapshot.data() } : snapshot.data();
 };
 
 export {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -268,8 +268,15 @@ const _addFirestoreListener = function _addFirestoreListener(
   );
 };
 
+const _getSegmentCount = function(path) {
+  return path.match(/^\//)
+    ? path.split('/').slice(1).length
+    : path.split('/').length;
+};
+
 export {
   _createHash,
+  _getSegmentCount,
   _addQueries,
   _returnRef,
   _setState,

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -189,6 +189,10 @@ const _updateSyncState = function(ref, onFailure, keepKeys, data) {
   }
 };
 
+const _fsUpdateSyncState = function(ref, data) {
+  ref.set(data);
+};
+
 const _addListener = function _addListener(
   id,
   invoker,
@@ -197,9 +201,10 @@ const _addListener = function _addListener(
   listeners
 ) {
   ref = _addQueries(ref, options.queries);
-  const boundOnFailure = typeof options.onFailure === 'function'
-    ? options.onFailure.bind(options.context)
-    : null;
+  const boundOnFailure =
+    typeof options.onFailure === 'function'
+      ? options.onFailure.bind(options.context)
+      : null;
   listeners.set(
     id,
     ref.on(
@@ -279,9 +284,12 @@ export {
   _addSync,
   _firebaseRefsMixin,
   _updateSyncState,
+  _fsUpdateSyncState,
   _addListener,
+  _addFirestoreListener,
   _setUnmountHandler,
   _createNestedObject,
   _handleError,
-  _setData
+  _setData,
+  _fsSetUnmountHandler
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -222,6 +222,33 @@ const _addListener = function _addListener(
   );
 };
 
+const _addFirestoreListener = function _addFirestoreListener(
+  id,
+  invoker,
+  options,
+  ref,
+  listeners
+) {
+  ref = _addQueries(ref, options.queries);
+  listeners.set(
+    id,
+    ref.onSnapshot(snapshot => {
+      if (snapshot.exists) {
+        const newState = options.state
+          ? { [options.state]: snapshot.data() }
+          : snapshot.data();
+        options.reactSetState.call(options.context, function(currentState) {
+          return Object.assign(currentState, newState);
+        });
+      }
+      if (options.then && options.then.called === false) {
+        options.then.call(options.context);
+        options.then.called = true;
+      }
+    })
+  );
+};
+
 export {
   _createHash,
   _addQueries,

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -1,4 +1,4 @@
-import { _isObject, _isValid, _throwError } from './utils';
+import { _isObject, _isValid, _throwError, _getSegmentCount } from './utils';
 
 const optionValidators = {
   notObject(options) {
@@ -124,12 +124,6 @@ const _validateCollectionPath = function(path) {
   if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
   const segmentCount = _getSegmentCount(path);
   if (segmentCount % 2 === 0) _throwError(defaultError, 'INVALID_ENDPOINT');
-};
-
-const _getSegmentCount = function(path) {
-  return path.match(/^\//)
-    ? path.split('/').slice(1).length
-    : path.split('/').length;
 };
 
 export {

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -101,8 +101,8 @@ const _validateEndpoint = function(endpoint) {
 const _validateDatabase = function(db) {
   var defaultError = 'Rebase.createClass failed.';
   var errorMsg;
-  if (typeof db !== 'object' || !db.ref) {
-    errorMsg = `${defaultError} Expected an initialized firebase database object.`;
+  if (typeof db !== 'object' || (!db.ref && !db.collection)) {
+    errorMsg = `${defaultError} Expected an initialized firebase or firestore database object.`;
   } else if (!db || arguments.length > 1) {
     errorMsg = `${defaultError} expects 1 argument.`;
   }

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -115,17 +115,21 @@ const _validateDatabase = function(db) {
 const _validateDocumentPath = function(path) {
   var defaultError = 'Invalid document path.';
   if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
-  const segmentCount = path.match(/^\//)
-    ? path.split('/').slice(1).length
-    : path.split('/').length;
+  const segmentCount = _getSegmentCount(path);
   if (segmentCount % 2 !== 0) _throwError(defaultError, 'INVALID_ENDPOINT');
 };
 
 const _validateCollectionPath = function(path) {
   var defaultError = 'Invalid collection path.';
   if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
-  const segmentCount = path.split('/').slice(1).length;
-  if (segmentCount % 2 !== 0) _throwError(defaultError, 'INVALID_ENDPOINT');
+  const segmentCount = _getSegmentCount(path);
+  if (segmentCount % 2 === 0) _throwError(defaultError, 'INVALID_ENDPOINT');
+};
+
+const _getSegmentCount = function(path) {
+  return path.match(/^\//)
+    ? path.split('/').slice(1).length
+    : path.split('/').length;
 };
 
 export {

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -82,13 +82,15 @@ const optionValidators = {
 };
 
 const _validateEndpoint = function(endpoint) {
-  const { DocumentReference, CollectionReference } = firebase.firestore;
-  if (typeof endpoint === 'object') {
-    if (
-      endpoint instanceof DocumentReference ||
-      endpoint instanceof CollectionReference
-    ) {
-      return;
+  if (firebase.firestore) {
+    const { DocumentReference, CollectionReference } = firebase.firestore;
+    if (typeof endpoint === 'object') {
+      if (
+        endpoint instanceof DocumentReference ||
+        endpoint instanceof CollectionReference
+      ) {
+        return;
+      }
     }
   }
   var defaultError = 'The Firebase endpoint you are trying to listen to';

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -103,10 +103,7 @@ const _validateDatabase = function(db) {
   var errorMsg;
   if (typeof db !== 'object' || (!db.ref && !db.collection)) {
     errorMsg = `${defaultError} Expected an initialized firebase or firestore database object.`;
-  } else if (!db || arguments.length > 1) {
-    errorMsg = `${defaultError} expects 1 argument.`;
   }
-
   if (typeof errorMsg !== 'undefined') {
     _throwError(errorMsg, 'INVALID_CONFIG');
   }

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -115,8 +115,10 @@ const _validateDatabase = function(db) {
 const _validateDocumentPath = function(path) {
   var defaultError = 'Invalid document path.';
   if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
-  const segmentCount = path.split('/').slice(1).length;
-  if (segmentCount % 2 === 0) _throwError(defaultError, 'INVALID_ENDPOINT');
+  const segmentCount = path.match(/^\//)
+    ? path.split('/').slice(1).length
+    : path.split('/').length;
+  if (segmentCount % 2 !== 0) _throwError(defaultError, 'INVALID_ENDPOINT');
 };
 
 const _validateCollectionPath = function(path) {

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -119,9 +119,17 @@ const _validateDocumentPath = function(path) {
   if (segmentCount % 2 === 0) _throwError(defaultError, 'INVALID_ENDPOINT');
 };
 
+const _validateCollectionPath = function(path) {
+  var defaultError = 'Invalid collection path.';
+  if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
+  const segmentCount = path.split('/').slice(1).length;
+  if (segmentCount % 2 !== 0) _throwError(defaultError, 'INVALID_ENDPOINT');
+};
+
 export {
   optionValidators,
   _validateDatabase,
   _validateEndpoint,
-  _validateDocumentPath
+  _validateDocumentPath,
+  _validateCollectionPath
 };

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -53,7 +53,9 @@ const optionValidators = {
     for (var key in queries) {
       if (queries.hasOwnProperty(key) && validQueries.indexOf(key) === -1) {
         _throwError(
-          `The query field must contain valid Firebase queries.  Expected one of [${validQueries.join(', ')}]. Instead, got ${key}`,
+          `The query field must contain valid Firebase queries.  Expected one of [${validQueries.join(
+            ', '
+          )}]. Instead, got ${key}`,
           'INVALID_OPTIONS'
         );
       }
@@ -110,4 +112,16 @@ const _validateDatabase = function(db) {
   }
 };
 
-export { optionValidators, _validateDatabase, _validateEndpoint };
+const _validateDocumentPath = function(path) {
+  var defaultError = 'Invalid document path.';
+  if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
+  const segmentCount = path.split('/').slice(1).length;
+  if (segmentCount % 2 === 0) _throwError(defaultError, 'INVALID_ENDPOINT');
+};
+
+export {
+  optionValidators,
+  _validateDatabase,
+  _validateEndpoint,
+  _validateDocumentPath
+};

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -1,4 +1,5 @@
 import { _isObject, _isValid, _throwError, _getSegmentCount } from './utils';
+import firebase from 'firebase/app';
 
 const optionValidators = {
   notObject(options) {
@@ -81,6 +82,15 @@ const optionValidators = {
 };
 
 const _validateEndpoint = function(endpoint) {
+  const { DocumentReference, CollectionReference } = firebase.firestore;
+  if (typeof endpoint === 'object') {
+    if (
+      endpoint instanceof DocumentReference ||
+      endpoint instanceof CollectionReference
+    ) {
+      return;
+    }
+  }
   var defaultError = 'The Firebase endpoint you are trying to listen to';
   var errorMsg;
   if (typeof endpoint !== 'string') {
@@ -110,14 +120,18 @@ const _validateDatabase = function(db) {
 };
 
 const _validateDocumentPath = function(path) {
-  var defaultError = 'Invalid document path.';
+  const { DocumentReference } = firebase.firestore;
+  if (typeof path === 'object' && path instanceof DocumentReference) return;
+  var defaultError = 'Invalid document path or reference.';
   if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
   const segmentCount = _getSegmentCount(path);
   if (segmentCount % 2 !== 0) _throwError(defaultError, 'INVALID_ENDPOINT');
 };
 
 const _validateCollectionPath = function(path) {
-  var defaultError = 'Invalid collection path.';
+  const { CollectionReference } = firebase.firestore;
+  if (typeof path === 'object' && path instanceof CollectionReference) return;
+  var defaultError = 'Invalid collection path or reference.';
   if (typeof path !== 'string') _throwError(defaultError, 'INVALID_ENDPOINT');
   const segmentCount = _getSegmentCount(path);
   if (segmentCount % 2 === 0) _throwError(defaultError, 'INVALID_ENDPOINT');

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -17,6 +17,7 @@ import _remove from './lib/remove';
 import _fsSync from './lib/fsSync';
 import _fsRemoveBinding from './lib/fsRemoveBinding';
 import _fsBind from './lib/fsBind';
+import _fsGet from './lib/fsGet';
 
 module.exports = (function() {
   function init(db) {
@@ -122,7 +123,9 @@ module.exports = (function() {
           },
           addToCollection() {},
           updateDoc() {},
-          get() {},
+          get(path, options) {
+            return _fsGet.call(this, path, options, db);
+          },
           removeDoc() {},
           removeCollection() {},
           removeBinding(binding) {

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -113,7 +113,13 @@ module.exports = (function() {
               listeners
             });
           },
-          listenToCollection() {},
+          listenToCollection(path, options) {
+            return _fsBind.call(this, path, options, 'listenToCollection', {
+              db,
+              refs,
+              listeners
+            });
+          },
           addToCollection() {},
           updateDoc() {},
           get() {},

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -21,8 +21,8 @@ import _fsBind from './lib/fsBind';
 module.exports = (function() {
   function init(db) {
     return (function() {
-      var firebaseRefs = new Map();
-      var firebaseListeners = new Map();
+      var refs = new Map();
+      var listeners = new Map();
       var syncs = new WeakMap();
 
       if (typeof db.ref === 'function') {
@@ -30,25 +30,25 @@ module.exports = (function() {
           initializedApp: db.app,
           listenTo(endpoint, options) {
             return _bind.call(this, endpoint, options, 'listenTo', {
-              db: db,
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              db,
+              refs,
+              listeners,
+              syncs
             });
           },
           bindToState(endpoint, options) {
             return _bind.call(this, endpoint, options, 'bindToState', {
-              db: db,
-              refs: firebaseRefs,
-              listeners: firebaseListeners
+              db,
+              refs,
+              listeners
             });
           },
           syncState(endpoint, options) {
             return _sync.call(this, endpoint, options, {
-              db: db,
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              db,
+              refs,
+              listeners,
+              syncs
             });
           },
           fetch(endpoint, options) {
@@ -58,18 +58,16 @@ module.exports = (function() {
             return _post(endpoint, options, db);
           },
           update(endpoint, options) {
-            return _update(endpoint, options, {
-              db: db
-            });
+            return _update(endpoint, options, { db });
           },
           push(endpoint, options) {
             return _push(endpoint, options, db);
           },
           removeBinding(binding) {
             _removeBinding(binding, {
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              refs,
+              listeners,
+              syncs
             });
           },
           remove(endpoint, fn) {
@@ -77,9 +75,9 @@ module.exports = (function() {
           },
           reset() {
             return _reset({
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              refs,
+              listeners,
+              syncs
             });
           }
         };
@@ -88,18 +86,25 @@ module.exports = (function() {
           initializedApp: db.app,
           bindDoc(path, options) {
             return _fsBind.call(this, path, options, 'listenDoc', {
-              db: db,
-              refs: firebaseRefs,
-              listeners: firebaseListeners
+              db,
+              refs,
+              listeners,
+              syncs
             });
           },
-          bindCollection() {},
+          bindCollection(path, options) {
+            return _fsBind.call(this, path, options, 'bindCollection', {
+              db,
+              refs,
+              listeners
+            });
+          },
           syncDoc(doc, options) {
             return _fsSync.call(this, doc, options, {
-              db: db,
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              db,
+              refs,
+              listeners,
+              syncs
             });
           },
           listenToDoc() {},
@@ -111,16 +116,16 @@ module.exports = (function() {
           removeCollection() {},
           removeBinding(binding) {
             _fsRemoveBinding(binding, {
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              refs,
+              listeners,
+              syncs
             });
           },
           reset() {
             return _reset({
-              refs: firebaseRefs,
-              listeners: firebaseListeners,
-              syncs: syncs
+              refs,
+              listeners,
+              syncs
             });
           }
         };

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -20,6 +20,7 @@ import _fsBind from './lib/fsBind';
 import _fsGet from './lib/fsGet';
 import _fsRemoveDoc from './lib/fsRemoveDoc';
 import _fsAddToCollection from './lib/fsAddToCollection';
+import _fsRemoveFromCollection from './lib/fsRemoveFromCollection';
 
 module.exports = (function() {
   function init(db) {
@@ -133,7 +134,9 @@ module.exports = (function() {
           removeDoc(path) {
             return _fsRemoveDoc(path, db);
           },
-          removeCollection() {},
+          removeFromCollection(path, options) {
+            return _fsRemoveFromCollection(path, db, options);
+          },
           removeBinding(binding) {
             _fsRemoveBinding(binding, {
               refs,

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -16,6 +16,7 @@ import _remove from './lib/remove';
 //firestore
 import _fsSync from './lib/fsSync';
 import _fsRemoveBinding from './lib/fsRemoveBinding';
+import _fsBind from './lib/fsBind';
 
 module.exports = (function() {
   function init(db) {
@@ -85,7 +86,13 @@ module.exports = (function() {
       } else {
         var rebase = {
           initializedApp: db.app,
-          bindDoc() {},
+          bindDoc(path, options) {
+            return _fsBind.call(this, path, options, 'listenDoc', {
+              db: db,
+              refs: firebaseRefs,
+              listeners: firebaseListeners
+            });
+          },
           bindCollection() {},
           syncDoc(doc, options) {
             return _fsSync.call(this, doc, options, {

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -20,63 +20,94 @@ module.exports = (function() {
       var firebaseListeners = new Map();
       var syncs = new WeakMap();
 
-      return {
-        initializedApp: db.app,
-        listenTo(endpoint, options) {
-          return _bind.call(this, endpoint, options, 'listenTo', {
-            db: db,
-            refs: firebaseRefs,
-            listeners: firebaseListeners,
-            syncs: syncs
-          });
-        },
-        bindToState(endpoint, options) {
-          return _bind.call(this, endpoint, options, 'bindToState', {
-            db: db,
-            refs: firebaseRefs,
-            listeners: firebaseListeners
-          });
-        },
-        syncState(endpoint, options) {
-          return _sync.call(this, endpoint, options, {
-            db: db,
-            refs: firebaseRefs,
-            listeners: firebaseListeners,
-            syncs: syncs
-          });
-        },
-        fetch(endpoint, options) {
-          return _fetch(endpoint, options, db);
-        },
-        post(endpoint, options) {
-          return _post(endpoint, options, db);
-        },
-        update(endpoint, options) {
-          return _update(endpoint, options, {
-            db: db
-          });
-        },
-        push(endpoint, options) {
-          return _push(endpoint, options, db);
-        },
-        removeBinding(binding) {
-          _removeBinding(binding, {
-            refs: firebaseRefs,
-            listeners: firebaseListeners,
-            syncs: syncs
-          });
-        },
-        remove(endpoint, fn) {
-          return _remove(endpoint, db, fn);
-        },
-        reset() {
-          return _reset({
-            refs: firebaseRefs,
-            listeners: firebaseListeners,
-            syncs: syncs
-          });
-        }
-      };
+      if (typeof db.ref === 'function') {
+        var rebase = {
+          initializedApp: db.app,
+          listenTo(endpoint, options) {
+            return _bind.call(this, endpoint, options, 'listenTo', {
+              db: db,
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          },
+          bindToState(endpoint, options) {
+            return _bind.call(this, endpoint, options, 'bindToState', {
+              db: db,
+              refs: firebaseRefs,
+              listeners: firebaseListeners
+            });
+          },
+          syncState(endpoint, options) {
+            return _sync.call(this, endpoint, options, {
+              db: db,
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          },
+          fetch(endpoint, options) {
+            return _fetch(endpoint, options, db);
+          },
+          post(endpoint, options) {
+            return _post(endpoint, options, db);
+          },
+          update(endpoint, options) {
+            return _update(endpoint, options, {
+              db: db
+            });
+          },
+          push(endpoint, options) {
+            return _push(endpoint, options, db);
+          },
+          removeBinding(binding) {
+            _removeBinding(binding, {
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          },
+          remove(endpoint, fn) {
+            return _remove(endpoint, db, fn);
+          },
+          reset() {
+            return _reset({
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          }
+        };
+      } else {
+        var rebase = {
+          initializedApp: db.app,
+          bindDoc() {},
+          bindCollection() {},
+          syncDoc() {},
+          listenToDoc() {},
+          listenToCollection() {},
+          addToCollection() {},
+          updateDoc() {},
+          get() {},
+          removeDoc() {},
+          removeCollection() {},
+          removeBinding(binding) {
+            _removeBinding(binding, {
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          },
+          reset() {
+            return _reset({
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          }
+        };
+      }
+      return rebase;
     })();
   }
 

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -19,6 +19,7 @@ import _fsRemoveBinding from './lib/fsRemoveBinding';
 import _fsBind from './lib/fsBind';
 import _fsGet from './lib/fsGet';
 import _fsRemoveDoc from './lib/fsRemoveDoc';
+import _fsAddToCollection from './lib/fsAddToCollection';
 
 module.exports = (function() {
   function init(db) {
@@ -122,8 +123,10 @@ module.exports = (function() {
               listeners
             });
           },
-          addToCollection() {},
-          updateDoc() {},
+          addToCollection(path, doc, key) {
+            return _fsAddToCollection.call(this, path, doc, db, key);
+          },
+          updateDoc(path, doc, key) {},
           get(path, options) {
             return _fsGet.call(this, path, options, db);
           },

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -106,7 +106,13 @@ module.exports = (function() {
               syncs
             });
           },
-          listenToDoc() {},
+          listenToDoc(doc, options) {
+            return _fsBind.call(this, doc, options, 'listenToDoc', {
+              db,
+              refs,
+              listeners
+            });
+          },
           listenToCollection() {},
           addToCollection() {},
           updateDoc() {},

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -21,6 +21,7 @@ import _fsGet from './lib/fsGet';
 import _fsRemoveDoc from './lib/fsRemoveDoc';
 import _fsAddToCollection from './lib/fsAddToCollection';
 import _fsRemoveFromCollection from './lib/fsRemoveFromCollection';
+import _fsUpdateDoc from './lib/fsUpdateDoc';
 
 module.exports = (function() {
   function init(db) {
@@ -127,7 +128,9 @@ module.exports = (function() {
           addToCollection(path, doc, key) {
             return _fsAddToCollection.call(this, path, doc, db, key);
           },
-          updateDoc(path, doc, key) {},
+          updateDoc(path, doc, options) {
+            return _fsUpdateDoc.call(this, path, doc, db);
+          },
           get(path, options) {
             return _fsGet.call(this, path, options, db);
           },

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -18,6 +18,7 @@ import _fsSync from './lib/fsSync';
 import _fsRemoveBinding from './lib/fsRemoveBinding';
 import _fsBind from './lib/fsBind';
 import _fsGet from './lib/fsGet';
+import _fsRemoveDoc from './lib/fsRemoveDoc';
 
 module.exports = (function() {
   function init(db) {
@@ -126,7 +127,9 @@ module.exports = (function() {
           get(path, options) {
             return _fsGet.call(this, path, options, db);
           },
-          removeDoc() {},
+          removeDoc(path) {
+            return _fsRemoveDoc(path, db);
+          },
           removeCollection() {},
           removeBinding(binding) {
             _fsRemoveBinding(binding, {

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -85,11 +85,10 @@ module.exports = (function() {
         var rebase = {
           initializedApp: db.app,
           bindDoc(path, options) {
-            return _fsBind.call(this, path, options, 'listenDoc', {
+            return _fsBind.call(this, path, options, 'bindDoc', {
               db,
               refs,
-              listeners,
-              syncs
+              listeners
             });
           },
           bindCollection(path, options) {

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -22,6 +22,7 @@ import _fsRemoveDoc from './lib/fsRemoveDoc';
 import _fsAddToCollection from './lib/fsAddToCollection';
 import _fsRemoveFromCollection from './lib/fsRemoveFromCollection';
 import _fsUpdateDoc from './lib/fsUpdateDoc';
+import _fsReset from './lib/fsReset';
 
 module.exports = (function() {
   function init(db) {
@@ -148,7 +149,7 @@ module.exports = (function() {
             });
           },
           reset() {
-            return _reset({
+            return _fsReset({
               refs,
               listeners,
               syncs

--- a/src/rebase.js
+++ b/src/rebase.js
@@ -13,6 +13,10 @@ import _reset from './lib/reset';
 import _removeBinding from './lib/removeBinding';
 import _remove from './lib/remove';
 
+//firestore
+import _fsSync from './lib/fsSync';
+import _fsRemoveBinding from './lib/fsRemoveBinding';
+
 module.exports = (function() {
   function init(db) {
     return (function() {
@@ -83,7 +87,14 @@ module.exports = (function() {
           initializedApp: db.app,
           bindDoc() {},
           bindCollection() {},
-          syncDoc() {},
+          syncDoc(doc, options) {
+            return _fsSync.call(this, doc, options, {
+              db: db,
+              refs: firebaseRefs,
+              listeners: firebaseListeners,
+              syncs: syncs
+            });
+          },
           listenToDoc() {},
           listenToCollection() {},
           addToCollection() {},
@@ -92,7 +103,7 @@ module.exports = (function() {
           removeDoc() {},
           removeCollection() {},
           removeBinding(binding) {
-            _removeBinding(binding, {
+            _fsRemoveBinding(binding, {
               refs: firebaseRefs,
               listeners: firebaseListeners,
               syncs: syncs

--- a/tests/firestore.rules
+++ b/tests/firestore.rules
@@ -1,0 +1,7 @@
+service cloud.firestore {
+  match /databases/{database}/documents {
+   match /testCollection/{doc} {
+   		allow read, write;
+   }
+  }
+}

--- a/tests/fixtures/dummyCollection.js
+++ b/tests/fixtures/dummyCollection.js
@@ -1,0 +1,32 @@
+module.exports = [
+  {
+    id: 1,
+    name: 'Document 1',
+    count: 1,
+    tags: ['tag1', 'tag2', 'tag3']
+  },
+  {
+    id: 2,
+    name: 'Document 2',
+    count: 1,
+    tags: ['tag1', 'tag2']
+  },
+  {
+    id: 3,
+    name: 'Document 3',
+    count: 3,
+    tags: ['tag1', 'tag2', 'tag3']
+  },
+  {
+    id: 4,
+    name: 'Document 4',
+    count: 1,
+    tags: ['tag1']
+  },
+  {
+    id: 5,
+    name: 'Document 5',
+    count: 2,
+    tags: ['tag1', 'tag2', 'tag3']
+  }
+];

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -19,6 +19,30 @@ exports.mockSnapshot = object => {
   return snapshot;
 };
 
+exports.mockFirestoreDocumentSnapshot = object => {
+  //set up snapshot
+  var snapshot = {
+    data() {
+      return object;
+    },
+    exists: true,
+    id: '12345',
+    ref: { _id: 'something' }
+  };
+  return snapshot;
+};
+
+exports.mockFirestoreQuerySnapshot = collection => {
+  //set up snapshot
+  var snapshot = {
+    forEach(cb) {
+      return collection.forEach(cb);
+    },
+    empty: collection.length
+  };
+  return snapshot;
+};
+
 exports.mockSyncs = data => new WeakMap(data);
 
 exports.mockRefs = data => new Map(data);

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,4 @@
-exports.mockSnapshot = (object) => {
+exports.mockSnapshot = object => {
   //set up snapshot
   var snapshot = {
     data: object,
@@ -23,7 +23,7 @@ exports.mockSyncs = data => new WeakMap(data);
 
 exports.mockRefs = data => new Map(data);
 
-exports.mockListeners = () => new Map();
+exports.mockListeners = data => new Map(data);
 
 exports.mockRef = () => {
   return {
@@ -44,6 +44,15 @@ exports.mockSync = data => ({
 
 exports.mockCollection = () => ({
   onSnapshot() {},
+  get() {},
+  add() {},
+  doc() {}
+});
+
+exports.mockDoc = unsubscribeSpy => ({
+  onSnapshot() {
+    return unsubscribeSpy;
+  },
   get() {},
   add() {},
   doc() {}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -6,38 +6,45 @@ exports.mockSnapshot = (object) => {
       Object.keys(this.data).forEach(key => {
         fn({
           val: () => {
-            return {[key]: this.data[key]};
+            return { [key]: this.data[key] };
           },
           key: key
-        })
-      })
+        });
+      });
     },
     val() {
       return this.data;
     }
   };
   return snapshot;
-}
+};
 
-exports.mockSyncs = (data) => new WeakMap(data);
+exports.mockSyncs = data => new WeakMap(data);
 
-exports.mockRefs = (data) => new Map(data);
+exports.mockRefs = data => new Map(data);
 
 exports.mockListeners = () => new Map();
 
 exports.mockRef = () => {
   return {
-    off(){},
-    on(){},
-    set(){},
-    child(prop){
+    off() {},
+    on() {},
+    set() {},
+    child(prop) {
       return this;
     }
-  }
+  };
 };
 
-exports.mockSync = (data) => ({
+exports.mockSync = data => ({
   id: data.id,
   updateFirebase: data.updateFirebase,
   stateKey: data.state
+});
+
+exports.mockCollection = () => ({
+  onSnapshot() {},
+  get() {},
+  add() {},
+  doc() {}
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -91,3 +91,10 @@ exports.mockDoc = unsubscribeSpy => ({
   add() {},
   doc() {}
 });
+
+exports.mockFirestore = (docSpy, collectionSpy) => {
+  return {
+    doc: docSpy,
+    collection: collectionSpy
+  };
+};

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -3,10 +3,20 @@ exports.mockSnapshot = object => {
   var snapshot = {
     data: object,
     forEach(fn) {
-      Object.keys(this.data).forEach(key => {
+      var values;
+      if (typeof this.data === 'object') {
+        values = Object.keys(this.data);
+      } else {
+        values = Array.isArray(this.data) ? this.data : [this.data];
+      }
+      values.forEach(key => {
         fn({
           val: () => {
-            return { [key]: this.data[key] };
+            if (this.data[key]) {
+              return { [key]: this.data[key] };
+            } else {
+              return key;
+            }
           },
           key: key
         });

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,22 +1,26 @@
 <!DOCTYPE HTML>
 <html>
-  <head>
-    <title>re-base Test Suite</title>
-    <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
-    <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
-    <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
-    <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
 
-    <script src="../node_modules/react/react.js"></script>
-    <script src="../node_modules/react/addons.js"></script>
+<head>
+  <title>re-base Test Suite</title>
+  <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+  <script src="../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+  <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
+  <link rel="stylesheet" href="../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
 
-    <script src="../node_modules/firebase/lib/firebase-web.js"></script>
+  <script src="../node_modules/react/react.js"></script>
+  <script src="../node_modules/react/addons.js"></script>
 
-    <script src="../dist/bundle.js"></script>
+  <script src="../node_modules/firebase/lib/firebase-web.js"></script>
 
-    <script src="specs/re-base.spec.js"></script>
-  </head>
+  <script src="../dist/bundle.js"></script>
+  <script>
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  </script>
+  <script src="specs/re-base.spec.js"></script>
+</head>
 
-  <body>
-  </body>
+<body>
+</body>
+
 </html>

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -2,17 +2,16 @@ var travis = process.env.TRAVIS;
 
 module.exports = function(config) {
   config.set({
-    frameworks: ["jasmine"],
+    frameworks: ['jasmine'],
     autowatch: true,
     singleRun: !!travis,
-    files: [
-      { pattern: 'specs/**/*.spec.js', watched: false }
-    ],
-    reporters: ["spec", "failed", "coverage"],
+    files: [{ pattern: 'specs/**/*.spec.js', watched: false }],
+    reporters: ['spec', 'failed', 'coverage'],
     browsers: [travis ? 'Firefox' : 'Chrome'],
     preprocessors: {
-    'specs/**/*.spec.js': ['webpack'],
+      'specs/**/*.spec.js': ['webpack']
     },
+    clearContext: false,
     webpack: {
       module: {
         loaders: [
@@ -33,12 +32,12 @@ module.exports = function(config) {
     coverageReporter: {
       reporters: [
         {
-          type: "lcovonly",
-          dir: "coverage",
-          subdir: "."
+          type: 'lcovonly',
+          dir: 'coverage',
+          subdir: '.'
         },
         {
-          type: "text-summary"
+          type: 'text-summary'
         }
       ]
     }

--- a/tests/specs/createClass.spec.js
+++ b/tests/specs/createClass.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../dist/bundle');
+const Rebase = require('../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');

--- a/tests/specs/createClass.spec.js
+++ b/tests/specs/createClass.spec.js
@@ -3,11 +3,12 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');
 var database = require('firebase/database');
+var firestore = require('firebase/firestore');
 
 var firebaseConfig = require('../fixtures/config');
 
 describe('createClass()', function() {
-  it('createClass() returns an object with the correct API', done => {
+  it('createClass() returns an object with the correct API for RTDB', done => {
     //setup
     var app = firebase.initializeApp(firebaseConfig);
     var db = firebase.database(app);
@@ -66,26 +67,97 @@ describe('createClass()', function() {
       });
   });
 
+  it('createClass() returns an object with the correct API for Firestore', done => {
+    //setup
+    var app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    var base = Rebase.createClass(db);
+
+    expect(base.bindDoc).toEqual(
+      jasmine.any(Function),
+      'Public API: bindDoc() not exposed'
+    );
+    expect(base.bindCollection).toEqual(
+      jasmine.any(Function),
+      'Public API: bindCollection() not exposed'
+    );
+    expect(base.syncDoc).toEqual(
+      jasmine.any(Function),
+      'Public API: syncDoc() not exposed'
+    );
+    expect(base.listenToDoc).toEqual(
+      jasmine.any(Function),
+      'Public API: listenToDoc() not exposed'
+    );
+    expect(base.listenToCollection).toEqual(
+      jasmine.any(Function),
+      'Public API: listenToCollection() not exposed'
+    );
+    expect(base.addToCollection).toEqual(
+      jasmine.any(Function),
+      'Public API: addToCollection() not exposed'
+    );
+    expect(base.updateDoc).toEqual(
+      jasmine.any(Function),
+      'Public API: updateDoc() not exposed'
+    );
+    expect(base.get).toEqual(
+      jasmine.any(Function),
+      'Public API: get() not exposed'
+    );
+    expect(base.removeDoc).toEqual(
+      jasmine.any(Function),
+      'Public API: removeDoc() not exposed'
+    );
+    expect(base.removeCollection).toEqual(
+      jasmine.any(Function),
+      'Public API: removeCollection() not exposed'
+    );
+    expect(base.removeBinding).toEqual(
+      jasmine.any(Function),
+      'Public API: removeBinding() not exposed'
+    );
+    expect(base.reset).toEqual(
+      jasmine.any(Function),
+      'Public API: reset() not exposed'
+    );
+    expect(base.initializedApp).toEqual(
+      jasmine.any(Object),
+      'Public API: initializedApp not exposed'
+    );
+    done();
+
+    //clean up
+    base = null;
+    db = null;
+    app
+      .delete()
+      .then(done)
+      .catch(() => {
+        done.fail('Firebase App not cleaned up after test');
+      });
+  });
+
   it('createClass() should throw if not passed an initialized firebase database instance', function() {
     expect(function() {
       Rebase.createClass({});
     }).toThrow(
       new Error(
-        'REBASE: Rebase.createClass failed. Expected an initialized firebase database object.'
+        'REBASE: Rebase.createClass failed. Expected an initialized firebase or firestore database object.'
       )
     );
     expect(function() {
       Rebase.createClass(database);
     }).toThrow(
       new Error(
-        'REBASE: Rebase.createClass failed. Expected an initialized firebase database object.'
+        'REBASE: Rebase.createClass failed. Expected an initialized firebase or firestore database object.'
       )
     );
     expect(function() {
       Rebase.createClass('some string');
     }).toThrow(
       new Error(
-        'REBASE: Rebase.createClass failed. Expected an initialized firebase database object.'
+        'REBASE: Rebase.createClass failed. Expected an initialized firebase or firestore database object.'
       )
     );
   });

--- a/tests/specs/createClass.spec.js
+++ b/tests/specs/createClass.spec.js
@@ -109,9 +109,9 @@ describe('createClass()', function() {
       jasmine.any(Function),
       'Public API: removeDoc() not exposed'
     );
-    expect(base.removeCollection).toEqual(
+    expect(base.removeFromCollection).toEqual(
       jasmine.any(Function),
-      'Public API: removeCollection() not exposed'
+      'Public API: removeFromCollection() not exposed'
     );
     expect(base.removeBinding).toEqual(
       jasmine.any(Function),

--- a/tests/specs/databases.spec.js
+++ b/tests/specs/databases.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../dist/bundle');
+const Rebase = require('../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');

--- a/tests/specs/databases.spec.js
+++ b/tests/specs/databases.spec.js
@@ -58,7 +58,7 @@ describe('Firebase/Firestore Interop', function() {
       .then(done);
   });
 
-  fit('both databases can be used side by side', done => {
+  it('both databases can be used side by side', done => {
     class TestComponent extends React.Component {
       constructor(props) {
         super(props);

--- a/tests/specs/databases.spec.js
+++ b/tests/specs/databases.spec.js
@@ -1,0 +1,100 @@
+var Rebase = require('../../dist/bundle');
+var React = require('react');
+var ReactDOM = require('react-dom');
+var firebase = require('firebase/app');
+require('firebase/database');
+require('firebase/firestore');
+
+var dummyArrData = require('../fixtures/dummyArrData');
+var dummyCollection = require('../fixtures/dummyCollection');
+var firebaseConfig = require('../fixtures/config');
+
+describe('Firebase/Firestore Interop', function() {
+  var base;
+  var fsBase;
+  var testEndpoint = 'test/bindToState';
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var testApp;
+  var ref;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    ref = testApp.database().ref();
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    testApp.delete().then(done);
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.database(app);
+    var fsDb = firebase.firestore(app);
+    base = Rebase.createClass(db);
+    fsBase = Rebase.createClass(fsDb);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.getElementById('mount'));
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      ref.child(testEndpoint).set(null)
+    ])
+      .then(() => app.delete())
+      .then(done);
+  });
+
+  fit('both databases can be used side by side', done => {
+    class TestComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          friends: [],
+          documents: []
+        };
+      }
+      componentWillMount() {
+        base.bindToState(`${testEndpoint}/myFriends`, {
+          context: this,
+          state: 'friends',
+          asArray: true
+        });
+        fsBase.bindCollection(collectionPath, {
+          state: 'documents',
+          context: this
+        });
+      }
+      componentDidMount() {
+        Promise.all(
+          ref.child(`${testEndpoint}/myFriends`).set(dummyArrData),
+          collectionRef.add(dummyCollection[0])
+        );
+      }
+      componentDidUpdate() {
+        if (this.state.friends.length && this.state.documents.length) {
+          expect(this.state.friends).toEqual(dummyArrData);
+          expect(this.state.documents[0]).toEqual(dummyCollection[0]);
+          done();
+        }
+      }
+      render() {
+        return <div>No Data</div>;
+      }
+    }
+    ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/addToCollection.spec.js
+++ b/tests/specs/firestore/addToCollection.spec.js
@@ -1,0 +1,91 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('addToCollection()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+  });
+
+  afterAll(done => {
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  it('validates paths', done => {
+    try {
+      base.addToCollection('testCollection/doc', dummyCollection[0]);
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_ENDPOINT');
+      done();
+    }
+  });
+
+  it('adds a document with a firestore generated id', done => {
+    collectionRef.onSnapshot(snap => {
+      if (!snap.empty) {
+        snap.forEach(doc => {
+          expect(doc.data().name).toEqual('Document 1');
+        });
+        done();
+      }
+    });
+    base
+      .addToCollection(`${collectionPath}`, dummyCollection[0])
+      .catch(err => done.fail(err));
+  });
+
+  it('adds a document with provided id', done => {
+    collectionRef.onSnapshot(snap => {
+      if (!snap.empty) {
+        expect(snap.docs[0].id).toEqual('my-id');
+        done();
+      }
+    });
+    base
+      .addToCollection(`${collectionPath}`, dummyCollection[0], 'my-id')
+      .catch(err => done.fail(err));
+  });
+
+  it('rejects on permissions error', done => {
+    base
+      .addToCollection('writeFail', dummyCollection[0], 'my-id')
+      .then(() => done.fail('should reject'))
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        done();
+      });
+  });
+});

--- a/tests/specs/firestore/addToCollection.spec.js
+++ b/tests/specs/firestore/addToCollection.spec.js
@@ -79,6 +79,19 @@ describe('addToCollection()', function() {
       .catch(err => done.fail(err));
   });
 
+  it('accepts a collection reference', done => {
+    const testRef = app.firestore().collection('testCollection');
+    collectionRef.onSnapshot(snap => {
+      if (!snap.empty) {
+        expect(snap.docs[0].id).toEqual('my-id');
+        done();
+      }
+    });
+    base
+      .addToCollection(testRef, dummyCollection[0], 'my-id')
+      .catch(err => done.fail(err));
+  });
+
   it('rejects on permissions error', done => {
     base
       .addToCollection('writeFail', dummyCollection[0], 'my-id')

--- a/tests/specs/firestore/addToCollection.spec.js
+++ b/tests/specs/firestore/addToCollection.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/bindCollection.spec.js
+++ b/tests/specs/firestore/bindCollection.spec.js
@@ -1,0 +1,411 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('bindCollection()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  function seedCollection() {
+    const docs = dummyCollection.map(doc => {
+      return collectionRef.add(doc);
+    });
+    return Promise.all(docs);
+  }
+
+  it('bindCollection() throws an error given a invalid endpoint', done => {
+    try {
+      base.bindCollection('testCollection/testDoc', {
+        context: { setState: () => {} },
+        state: 'prop',
+        then() {
+          done.fail('error should have been thrown');
+        }
+      });
+    } catch (err) {
+      expect(err).not.toBe(null);
+      done();
+    }
+  });
+
+  describe('Async tests', function() {
+    it('bindCollection() invokes .then when the initial listener is set', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            loading: true
+          };
+        }
+        componentDidMount() {
+          this.ref = base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'user',
+            then() {
+              this.setState(
+                {
+                  loading: false
+                },
+                () => {
+                  expect(this.state.loading).toEqual(false);
+                  done();
+                }
+              );
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() invokes .onFailure with error if permissions do not allow read', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            loading: true,
+            user: {}
+          };
+        }
+        componentDidMount() {
+          var self = this;
+          this.ref = base.bindCollection(`/readsFail`, {
+            context: this,
+            state: 'user',
+            onFailure(err) {
+              expect(this).toEqual(self);
+              expect(this.setState).toEqual(self.setState);
+              expect(err).not.toBeUndefined();
+              done();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() returns no data if the collection does not exist', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            emptyObj: {
+              value: {}
+            },
+            kickOffUpdate: false
+          };
+        }
+        componentDidMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'emptyObj',
+            then() {
+              this.forceUpdate();
+            }
+          });
+        }
+        componentDidUpdate() {
+          expect(this.state.emptyObj.value).toEqual({});
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() properly updates the local state property when the collection changes', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidMount() {
+          seedCollection().then(() => {
+            setTimeout(() => {
+              expect(this.state.data.length).toEqual(5);
+              done();
+            }, 500);
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() can apply a simple query', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data',
+            query: ref => ref.where('name', '==', 'Document 1')
+          });
+        }
+        componentDidMount() {
+          seedCollection().then(() => {
+            setTimeout(() => {
+              expect(this.state.data.length).toEqual(1);
+              expect(this.state.data[0].name).toEqual('Document 1');
+              done();
+            }, 500);
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() can apply a compound query', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data',
+            query: ref =>
+              ref
+                .where('id', '<', 5)
+                .where('id', '>', 2)
+                .orderBy('id')
+          });
+        }
+        componentDidMount() {
+          seedCollection().then(() => {
+            setTimeout(() => {
+              expect(this.state.data.length).toEqual(2);
+              expect(this.state.data[0].name).toEqual('Document 3');
+              expect(this.state.data[1].name).toEqual('Document 4');
+              done();
+            }, 500);
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection should allow multiple components to listen to changes on the same endpoint', done => {
+      function cleanUp(done) {
+        ReactDOM.unmountComponentAtNode(document.getElementById('div1'));
+        ReactDOM.unmountComponentAtNode(document.getElementById('div2'));
+        done();
+      }
+      //set up mount points
+      var div1 = document.createElement('div');
+      div1.setAttribute('id', 'div1');
+
+      var div2 = document.createElement('div');
+      div2.setAttribute('id', 'div2');
+      document.getElementById('mount').appendChild(div1);
+      document.getElementById('mount').appendChild(div2);
+
+      //keep track of updates
+      var component1DidUpdate = false;
+      var component2DidUpdate = false;
+      var arrayLength = 0;
+
+      class TestComponent1 extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data'
+          });
+        }
+
+        componentDidUpdate() {
+          component1DidUpdate = true;
+          expect(arrayLength).toBeLessThan(this.state.data.length);
+          arrayLength = this.state.data.length;
+          if (component1DidUpdate && component2DidUpdate) {
+            cleanUp(done);
+          }
+        }
+        render() {
+          return <div />;
+        }
+      }
+
+      class TestComponent2 extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: {}
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidMount() {
+          seedCollection().then(() => {
+            setTimeout(() => {
+              expect(this.state.data.length).toEqual(5);
+              component2DidUpdate = true;
+              if (component1DidUpdate && component2DidUpdate) {
+                cleanUp(done);
+              }
+            }, 200);
+          });
+        }
+        render() {
+          return <div />;
+        }
+      }
+      ReactDOM.render(<TestComponent1 />, document.getElementById('div1'));
+      ReactDOM.render(<TestComponent2 />, document.getElementById('div2'));
+    });
+  });
+
+  it('listeners are removed when component unmounts', done => {
+    spyOn(console, 'error');
+    var componentWillMountSpy = jasmine.createSpy('componentWillMountSpy');
+    class ChildComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {}
+        };
+      }
+
+      componentWillMount() {
+        base.bindCollection(`${collectionPath}`, {
+          context: this,
+          state: 'data'
+        });
+      }
+
+      componentWillUnmount() {
+        componentWillMountSpy('additional clean up performed');
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    class ParentComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          showChild: true
+        };
+      }
+
+      setData(cb) {
+        collectionRef
+          .doc('testDoc')
+          .set({
+            data: dummyCollection[0]
+          })
+          .then(cb);
+      }
+
+      componentDidMount() {
+        this.setState(
+          {
+            showChild: false
+          },
+          () => {
+            this.setData(() => {
+              expect(console.error).not.toHaveBeenCalled();
+              expect(componentWillMountSpy).toHaveBeenCalledWith(
+                'additional clean up performed'
+              );
+              done();
+            });
+          }
+        );
+      }
+
+      render() {
+        return <div>{this.state.showChild ? <ChildComponent /> : null}</div>;
+      }
+    }
+    ReactDOM.render(<ParentComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/bindCollection.spec.js
+++ b/tests/specs/firestore/bindCollection.spec.js
@@ -431,7 +431,7 @@ describe('bindCollection()', function() {
         constructor(props) {
           super(props);
           this.state = {
-            data: {}
+            data: []
           };
         }
         componentWillMount() {

--- a/tests/specs/firestore/bindCollection.spec.js
+++ b/tests/specs/firestore/bindCollection.spec.js
@@ -194,6 +194,65 @@ describe('bindCollection()', function() {
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('bindCollection() properly updates the local state property when the collection changes', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidMount() {
+          seedCollection().then(() => {
+            setTimeout(() => {
+              expect(this.state.data.length).toEqual(5);
+              done();
+            }, 500);
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() accepts collection reference', done => {
+      const testRef = app.firestore().collection('testCollection');
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(testRef, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidMount() {
+          seedCollection().then(() => {
+            setTimeout(() => {
+              expect(this.state.data.length).toEqual(5);
+              done();
+            }, 500);
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
     it('bindCollection() returns documents with embedded refrence if options.withRefs is true', done => {
       class TestComponent extends React.Component {
         constructor(props) {

--- a/tests/specs/firestore/bindCollection.spec.js
+++ b/tests/specs/firestore/bindCollection.spec.js
@@ -194,6 +194,66 @@ describe('bindCollection()', function() {
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('bindCollection() returns documents with embedded refrence if options.withRefs is true', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: {}
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data',
+            withRefs: true
+          });
+        }
+        componentDidMount() {
+          collectionRef.doc('testDoc').set(dummyCollection[0]);
+        }
+        componentDidUpdate() {
+          expect(this.state.data[0].ref).toEqual(
+            jasmine.any(firebase.firestore.DocumentReference)
+          );
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindCollection() returns documents with Firestore id embedded if options.withIds is true', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: {}
+          };
+        }
+        componentWillMount() {
+          base.bindCollection(`${collectionPath}`, {
+            context: this,
+            state: 'data',
+            withIds: true
+          });
+        }
+        componentDidMount() {
+          collectionRef.doc('testDoc').set(dummyCollection[0]);
+        }
+        componentDidUpdate() {
+          expect(this.state.data[0].id).toEqual(jasmine.any(String));
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
     it('bindCollection() can apply a simple query', done => {
       class TestComponent extends React.Component {
         constructor(props) {

--- a/tests/specs/firestore/bindCollection.spec.js
+++ b/tests/specs/firestore/bindCollection.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/bindDoc.spec.js
+++ b/tests/specs/firestore/bindDoc.spec.js
@@ -1,0 +1,380 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var dummyArrayOfObjects = require('../../fixtures/dummyArrayOfObjects');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var dummyArrData = require('../../fixtures/dummyArrData');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('bindDoc()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  it('bindDoc() throws an error given a invalid endpoint', done => {
+    try {
+      base.bindDoc('collection', {
+        context: { setState: () => {} },
+        state: 'prop',
+        then() {
+          done.fail('error should have been thrown');
+        }
+      });
+    } catch (err) {
+      expect(err).not.toBe(null);
+      done();
+    }
+  });
+
+  describe('Async tests', function() {
+    it('bindDoc() invokes .then when the initial listener is set', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            loading: true
+          };
+        }
+        componentDidMount() {
+          this.ref = base.bindDoc(`${collectionPath}/userData`, {
+            context: this,
+            state: 'user',
+            then() {
+              this.setState(
+                {
+                  loading: false
+                },
+                () => {
+                  expect(this.state.loading).toEqual(false);
+                  done();
+                }
+              );
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindDoc() invokes .onFailure with error if permissions do not allow read', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            loading: true,
+            user: {}
+          };
+        }
+        componentDidMount() {
+          var self = this;
+          this.ref = base.bindDoc(`/readsFail/testDoc`, {
+            context: this,
+            state: 'user',
+            onFailure(err) {
+              expect(this).toEqual(self);
+              expect(this.setState).toEqual(self.setState);
+              expect(err).not.toBeUndefined();
+              done();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindDoc() returns no data if the document does not exist', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            emptyObj: {
+              value: {}
+            },
+            emptyArr: {
+              value: []
+            },
+            kickOffUpdate: false
+          };
+        }
+        componentDidMount() {
+          base.bindDoc(`${collectionPath}/testDoc1`, {
+            context: this,
+            state: 'emptyObj'
+          });
+
+          base.bindDoc(`${collectionPath}/testDoce2`, {
+            context: this,
+            state: 'emptyArr',
+            then() {
+              this.forceUpdate();
+            }
+          });
+        }
+        componentDidUpdate() {
+          expect(this.state.emptyObj.value).toEqual({});
+          expect(this.state.emptyArr.value).toEqual([]);
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindDoc() properly updates the local state property when the document changes', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: {}
+          };
+        }
+        componentWillMount() {
+          base.bindDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidMount() {
+          collectionRef.doc('testDoc').set(dummyObjData);
+        }
+        componentDidUpdate() {
+          expect(this.state.data).toEqual(dummyObjData);
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('bindDoc should allow multiple components to listen to changes on the same endpoint', done => {
+      function cleanUp(done) {
+        ReactDOM.unmountComponentAtNode(document.getElementById('div1'));
+        ReactDOM.unmountComponentAtNode(document.getElementById('div2'));
+        done();
+      }
+
+      //set up mount points
+      var div1 = document.createElement('div');
+      div1.setAttribute('id', 'div1');
+
+      var div2 = document.createElement('div');
+      div2.setAttribute('id', 'div2');
+      document.getElementById('mount').appendChild(div1);
+      document.getElementById('mount').appendChild(div2);
+
+      //keep track of updates
+      var component1DidUpdate = false;
+      var component2DidUpdate = false;
+
+      class TestComponent1 extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: {}
+          };
+        }
+        componentWillMount() {
+          base.bindDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidUpdate() {
+          expect(this.state.data).toEqual(dummyObjData);
+          component1DidUpdate = true;
+          if (component1DidUpdate && component2DidUpdate) {
+            cleanUp(done);
+          }
+        }
+        render() {
+          return (
+            <div>
+              Name: {this.state.name} <br />
+              Age: {this.state.age}
+            </div>
+          );
+        }
+      }
+
+      class TestComponent2 extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: {}
+          };
+        }
+        componentWillMount() {
+          base.bindDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'data'
+          });
+        }
+        componentDidMount() {
+          collectionRef.doc('testDoc').set(dummyObjData);
+        }
+        componentDidUpdate() {
+          expect(this.state.data).toEqual(dummyObjData);
+          component2DidUpdate = true;
+          if (component1DidUpdate && component2DidUpdate) {
+            cleanUp(done);
+          }
+        }
+        render() {
+          return <div />;
+        }
+      }
+      ReactDOM.render(<TestComponent1 />, document.getElementById('div1'));
+      ReactDOM.render(<TestComponent2 />, document.getElementById('div2'));
+    });
+
+    it('bindDoc merges keys if no options.state prop is supplied', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            otherKey: ['something']
+          };
+        }
+        componentWillMount() {
+          base.bindDoc(`${collectionPath}/testDoc`, {
+            context: this
+          });
+        }
+        componentDidMount() {
+          collectionRef.doc('testDoc').set(dummyObjData);
+        }
+        componentDidUpdate() {
+          expect(this.state.name).toEqual('Tyler McGinnis');
+          expect(this.state.otherKey).toEqual(['something']);
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+  });
+
+  it('listeners are removed when component unmounts', done => {
+    spyOn(console, 'error');
+    var componentWillMountSpy = jasmine.createSpy('componentWillMountSpy');
+    class ChildComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {}
+        };
+      }
+
+      componentWillMount() {
+        base.bindDoc(`${collectionPath}/testDoc`, {
+          context: this,
+          state: 'data',
+          asArray: true
+        });
+      }
+
+      componentWillUnmount() {
+        componentWillMountSpy('additional clean up performed');
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    class ParentComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          showChild: true
+        };
+      }
+
+      setData(cb) {
+        collectionRef
+          .doc('testDoc')
+          .set({
+            data: dummyObjData
+          })
+          .then(cb);
+      }
+
+      componentDidMount() {
+        this.setState(
+          {
+            showChild: false
+          },
+          () => {
+            this.setData(() => {
+              expect(console.error).not.toHaveBeenCalled();
+              expect(componentWillMountSpy).toHaveBeenCalledWith(
+                'additional clean up performed'
+              );
+              done();
+            });
+          }
+        );
+      }
+
+      render() {
+        return <div>{this.state.showChild ? <ChildComponent /> : null}</div>;
+      }
+    }
+    ReactDOM.render(<ParentComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/bindDoc.spec.js
+++ b/tests/specs/firestore/bindDoc.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/bindDoc.spec.js
+++ b/tests/specs/firestore/bindDoc.spec.js
@@ -199,6 +199,37 @@ describe('bindDoc()', function() {
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('bindDoc() accepts a document reference', done => {
+      const docRef = collectionRef.doc('testDoc');
+      docRef.set(dummyObjData).then(() => {
+        class TestComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              data: {}
+            };
+          }
+          componentWillMount() {
+            base.bindDoc(docRef, {
+              context: this,
+              state: 'data'
+            });
+          }
+          componentDidMount() {
+            collectionRef.doc('testDoc').set(dummyObjData);
+          }
+          componentDidUpdate() {
+            expect(this.state.data).toEqual(dummyObjData);
+            done();
+          }
+          render() {
+            return <div>No Data</div>;
+          }
+        }
+        ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+      });
+    });
+
     it('bindDoc should allow multiple components to listen to changes on the same endpoint', done => {
       function cleanUp(done) {
         ReactDOM.unmountComponentAtNode(document.getElementById('div1'));

--- a/tests/specs/firestore/get.spec.js
+++ b/tests/specs/firestore/get.spec.js
@@ -159,6 +159,17 @@ describe('get()', function() {
         .catch(err => done.fail(err));
     });
 
+    it('get() accepts a collection reference', done => {
+      const testRef = app.firestore().collection('testCollection');
+      base
+        .get(testRef)
+        .then(data => {
+          expect(data[0].name).toEqual(dummyCollection[0].name);
+          done();
+        })
+        .catch(err => done.fail(err));
+    });
+
     it('get() rejects Promise when read fails or is denied', done => {
       base
         .get('/readFail')

--- a/tests/specs/firestore/get.spec.js
+++ b/tests/specs/firestore/get.spec.js
@@ -1,0 +1,150 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('get()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  function seedCollection() {
+    const docs = dummyCollection.map((doc, index) => {
+      const docRef = collectionRef.doc(`doc-${index + 1}`);
+      return docRef.set(doc);
+    });
+    return Promise.all(docs);
+  }
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(done => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+    seedCollection().then(done);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  it('get() validates endpoint', done => {
+    try {
+      base.get('').then(() => {
+        done.fail('error should thrown');
+      });
+    } catch (err) {
+      expect(err).not.toBeNull(err);
+      done();
+    }
+  });
+
+  describe('Async tests', function() {
+    it('get() resolves with data from a collection', done => {
+      base
+        .get(collectionPath)
+        .then(data => {
+          expect(data.length).toEqual(5);
+          done();
+        })
+        .catch(err => done.fail(err));
+    });
+
+    it('get() resolves with data from a collection query', done => {
+      base
+        .get(`${collectionPath}`, {
+          query: ref =>
+            ref
+              .where('id', '<', 5)
+              .where('id', '>', 2)
+              .orderBy('id')
+        })
+        .then(data => {
+          expect(data.length).toEqual(2);
+          expect(data[0].name).toEqual('Document 3');
+          expect(data[1].name).toEqual('Document 4');
+          done();
+        })
+        .catch(err => done.fail(err));
+    });
+
+    it('get() rejects if collection query returns no results', done => {
+      base
+        .get(`${collectionPath}`, {
+          query: ref => ref.where('id', '>', 5).orderBy('id')
+        })
+        .then(data => {
+          done.fail('query should reject');
+        })
+        .catch(err => {
+          expect(err.message).toEqual('No Result');
+          done();
+        });
+    });
+
+    it('get() rejects if document does not exist', done => {
+      base
+        .get(`${collectionPath}/nodoc`)
+        .then(data => {
+          done.fail('query should reject');
+        })
+        .catch(err => {
+          expect(err.message).toEqual('No Result');
+          done();
+        });
+    });
+
+    it('get() resolves with a document', done => {
+      base
+        .get(`${collectionPath}/doc-1`)
+        .then(data => {
+          expect(data.name).toEqual(dummyCollection[0].name);
+          done();
+        })
+        .catch(err => done.fail(err));
+    });
+
+    it('get() rejects Promise when read fails or is denied', done => {
+      base
+        .get('/readFail')
+        .then(() => {
+          done.fail('Promise should reject');
+        })
+        .catch(err => {
+          expect(err.code).toContain('permission-denied');
+          done();
+        });
+    });
+  });
+});

--- a/tests/specs/firestore/get.spec.js
+++ b/tests/specs/firestore/get.spec.js
@@ -135,6 +135,30 @@ describe('get()', function() {
         .catch(err => done.fail(err));
     });
 
+    it('get() resolves with a document', done => {
+      base
+        .get(`${collectionPath}/doc-1`)
+        .then(data => {
+          expect(data.name).toEqual(dummyCollection[0].name);
+          done();
+        })
+        .catch(err => done.fail(err));
+    });
+
+    it('get() accepts a document reference', done => {
+      const docRef = app
+        .firestore()
+        .collection('testCollection')
+        .doc('doc-1');
+      base
+        .get(docRef)
+        .then(data => {
+          expect(data.name).toEqual(dummyCollection[0].name);
+          done();
+        })
+        .catch(err => done.fail(err));
+    });
+
     it('get() rejects Promise when read fails or is denied', done => {
       base
         .get('/readFail')

--- a/tests/specs/firestore/get.spec.js
+++ b/tests/specs/firestore/get.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/listenToCollection.spec.js
+++ b/tests/specs/firestore/listenToCollection.spec.js
@@ -1,0 +1,329 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('listenToCollection()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  function seedCollection() {
+    const docs = dummyCollection.map(doc => {
+      return collectionRef.add(doc);
+    });
+    return Promise.all(docs);
+  }
+
+  it('listenToCollection() returns a valid ref', function() {
+    var ref = base.listenToCollection(`${collectionPath}`, {
+      context: this,
+      then(data) {}
+    });
+    expect(ref.id).toEqual(jasmine.any(Number));
+  });
+
+  it('listenToCollection() validates endpoints', done => {
+    try {
+      base.listenToCollection('collection/testDoc', {
+        context: { setState: () => {} },
+        state: 'prop',
+        then() {
+          done.fail('error should have been thrown');
+        }
+      });
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_ENDPOINT');
+      expect(err).not.toBe(null);
+      done();
+    }
+  });
+
+  it('listenToCollection() throws an error given an invalid options object', done => {
+    try {
+      base.listenToCollection(`${collectionPath}`, {
+        context: this
+      });
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_OPTIONS');
+      done();
+    }
+  });
+
+  describe('Async tests', function() {
+    it("listenToCollection()'s .then method gets invoked when the document changes", done => {
+      const ref = base.listenToCollection(`${collectionPath}`, {
+        context: {},
+        then(data) {
+          expect(data).toEqual([dummyCollection[0]]);
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it("listenToCollection's .onFailure method gets invoked in the component context with error if permissions do not allow read", done => {
+      const ref = base.listenToCollection('/readFail', {
+        context: this,
+        onFailure(err) {
+          expect(err).not.toBeUndefined();
+          expect(err.code).toEqual('permission-denied');
+          base.removeBinding(ref);
+          done();
+        },
+        then(data) {
+          done.fail(
+            'Database permissions should not allow read from this location'
+          );
+        }
+      });
+    });
+
+    it('listenToCollection embeds document reference if withRefs is true', done => {
+      const ref = base.listenToCollection(`${collectionPath}`, {
+        context: {},
+        withRefs: true,
+        then(data) {
+          expect(data[0].ref).toEqual(
+            jasmine.any(firebase.firestore.DocumentReference)
+          );
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it('listenToCollection embeds document id if withIds is true', done => {
+      const ref = base.listenToCollection(`${collectionPath}`, {
+        context: {},
+        withIds: true,
+        then(data) {
+          expect(data[0].id).toEqual(jasmine.any(String));
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it('listenToCollection() can apply a simple query', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          base.listenToCollection(`${collectionPath}`, {
+            context: this,
+            query: ref => ref.where('name', '==', 'Document 1'),
+            then(data) {
+              if (data.length) {
+                expect(data.length).toEqual(1);
+                expect(data[0].name).toEqual('Document 1');
+                done();
+              }
+            }
+          });
+        }
+        componentDidMount() {
+          seedCollection();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('listenToCollection() can apply a compound query', done => {
+      seedCollection().then(() => {
+        class TestComponent extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              data: []
+            };
+          }
+          componentWillMount() {
+            base.listenToCollection(`${collectionPath}`, {
+              context: this,
+              query: ref =>
+                ref
+                  .where('id', '<', 5)
+                  .where('id', '>', 2)
+                  .orderBy('id'),
+              then(data) {
+                expect(data.length).toEqual(2);
+                expect(data[0].name).toEqual('Document 3');
+                expect(data[1].name).toEqual('Document 4');
+                done();
+              }
+            });
+          }
+          componentDidMount() {}
+          render() {
+            return <div>No Data</div>;
+          }
+        }
+        ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+      });
+    });
+
+    it('listenToCollection should allow multiple listeners to same document', done => {
+      let updateCount = 0;
+      const ref1 = base.listenToCollection(`${collectionPath}`, {
+        context: {},
+        then(data) {
+          updateCount++;
+          expect(data[0]).toEqual(dummyCollection[0]);
+          base.removeBinding(ref1);
+          if (updateCount === 2) {
+            done();
+          }
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+      const ref2 = base.listenToCollection(`${collectionPath}`, {
+        context: {},
+        then(data) {
+          updateCount++;
+          expect(data[0]).toEqual(dummyCollection[0]);
+          base.removeBinding(ref2);
+          if (updateCount === 2) {
+            done();
+          }
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+  });
+
+  it('listeners are removed when component unmounts', done => {
+    spyOn(console, 'error');
+    var componentWillMountSpy = jasmine.createSpy('componentWillMountSpy');
+    class ChildComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {}
+        };
+      }
+
+      componentWillMount() {
+        base.listenToCollection(`${collectionPath}`, {
+          context: this,
+          then(data) {
+            this.setState({ data });
+          }
+        });
+        base.listenToCollection(`${collectionPath}`, {
+          context: this,
+          then(data) {
+            this.setState({ data });
+          }
+        });
+        base.listenToCollection(`${collectionPath}`, {
+          context: this,
+          then(data) {
+            this.setState({ data });
+          }
+        });
+      }
+
+      componentWillUnmount() {
+        componentWillMountSpy('additional clean up performed');
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    class ParentComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          showChild: true
+        };
+      }
+
+      setData(cb) {
+        Promise.all([
+          collectionRef.doc('testDoc1').set(dummyCollection[0]),
+          collectionRef.doc('testDoc2').set(dummyCollection[1]),
+          collectionRef.doc('testDoc3').set(dummyCollection[2])
+        ]).then(() => {
+          setTimeout(cb, 200);
+        });
+      }
+
+      componentDidMount() {
+        this.setState(
+          {
+            showChild: false
+          },
+          () => {
+            this.setData(() => {
+              expect(console.error).not.toHaveBeenCalled();
+              expect(componentWillMountSpy).toHaveBeenCalledWith(
+                'additional clean up performed'
+              );
+              done();
+            });
+          }
+        );
+      }
+
+      render() {
+        return <div>{this.state.showChild ? <ChildComponent /> : null}</div>;
+      }
+    }
+    ReactDOM.render(<ParentComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/listenToCollection.spec.js
+++ b/tests/specs/firestore/listenToCollection.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/listenToCollection.spec.js
+++ b/tests/specs/firestore/listenToCollection.spec.js
@@ -122,6 +122,19 @@ describe('listenToCollection()', function() {
       });
     });
 
+    it('listenToCollection() accepts a collection reference', done => {
+      const testRef = app.firestore().collection('testCollection');
+      const ref = base.listenToCollection(testRef, {
+        context: {},
+        then(data) {
+          expect(data).toEqual([dummyCollection[0]]);
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
     it('listenToCollection embeds document reference if withRefs is true', done => {
       const ref = base.listenToCollection(`${collectionPath}`, {
         context: {},

--- a/tests/specs/firestore/listenToDoc.spec.js
+++ b/tests/specs/firestore/listenToDoc.spec.js
@@ -1,0 +1,257 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('listenToDoc()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  it('listenToDoc() returns a valid ref', function() {
+    var ref = base.listenToDoc(`${collectionPath}/testDoc`, {
+      context: this,
+      then(data) {}
+    });
+    expect(ref.id).toEqual(jasmine.any(Number));
+  });
+
+  it('listenToDoc() validates endpoints', done => {
+    try {
+      base.listenToDoc('collection', {
+        context: { setState: () => {} },
+        state: 'prop',
+        then() {
+          done.fail('error should have been thrown');
+        }
+      });
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_ENDPOINT');
+      expect(err).not.toBe(null);
+      done();
+    }
+  });
+
+  it('listenToDoc() throws an error given an invalid options object', done => {
+    try {
+      base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: this
+      });
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_OPTIONS');
+      done();
+    }
+  });
+
+  describe('Async tests', function() {
+    it("listenToDoc()'s .then method gets invoked when the document changes", done => {
+      const ref = base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: {},
+        then(data) {
+          expect(data).toEqual(dummyCollection[0]);
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it("listenToDoc's .onFailure method gets invoked in the component context with error if permissions do not allow read", done => {
+      const ref = base.listenToDoc('/readFail/testDoc', {
+        context: this,
+        onFailure(err) {
+          expect(err).not.toBeUndefined();
+          expect(err.code).toEqual('permission-denied');
+          base.removeBinding(ref);
+          done();
+        },
+        then(data) {
+          done.fail(
+            'Database permissions should not allow read from this location'
+          );
+        }
+      });
+    });
+
+    it('listenToDoc embeds document reference if withRefs is true', done => {
+      const ref = base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: {},
+        withRefs: true,
+        then(data) {
+          expect(data.ref).toEqual(
+            jasmine.any(firebase.firestore.DocumentReference)
+          );
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it('listenToDoc embeds document id if withIds is true', done => {
+      const ref = base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: {},
+        withIds: true,
+        then(data) {
+          expect(data.id).toEqual(jasmine.any(String));
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it('listenToDoc should allow multiple listeners to same document', done => {
+      let updateCount = 0;
+      const ref1 = base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: {},
+        then(data) {
+          updateCount++;
+          expect(data).toEqual(dummyCollection[0]);
+          base.removeBinding(ref1);
+          if (updateCount === 2) {
+            done();
+          }
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+      const ref2 = base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: {},
+        then(data) {
+          updateCount++;
+          expect(data).toEqual(dummyCollection[0]);
+          base.removeBinding(ref2);
+          if (updateCount === 2) {
+            done();
+          }
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+  });
+
+  it('listeners are removed when component unmounts', done => {
+    spyOn(console, 'error');
+    var componentWillMountSpy = jasmine.createSpy('componentWillMountSpy');
+    class ChildComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {}
+        };
+      }
+
+      componentWillMount() {
+        base.listenToDoc(`${collectionPath}/testDoc1`, {
+          context: this,
+          then(data) {
+            this.setState({ data });
+          }
+        });
+        base.listenToDoc(`${collectionPath}/testDoc2`, {
+          context: this,
+          then(data) {
+            this.setState({ data });
+          }
+        });
+        base.listenToDoc(`${collectionPath}/testDoc3`, {
+          context: this,
+          then(data) {
+            this.setState({ data });
+          }
+        });
+      }
+
+      componentWillUnmount() {
+        componentWillMountSpy('additional clean up performed');
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    class ParentComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          showChild: true
+        };
+      }
+
+      setData(cb) {
+        Promise.all([
+          collectionRef.doc('testDoc1').set(dummyCollection[0]),
+          collectionRef.doc('testDoc2').set(dummyCollection[1]),
+          collectionRef.doc('testDoc3').set(dummyCollection[2])
+        ]).then(() => {
+          setTimeout(cb, 500);
+        });
+      }
+
+      componentDidMount() {
+        this.setState(
+          {
+            showChild: false
+          },
+          () => {
+            this.setData(() => {
+              expect(console.error).not.toHaveBeenCalled();
+              expect(componentWillMountSpy).toHaveBeenCalledWith(
+                'additional clean up performed'
+              );
+              done();
+            });
+          }
+        );
+      }
+
+      render() {
+        return <div>{this.state.showChild ? <ChildComponent /> : null}</div>;
+      }
+    }
+    ReactDOM.render(<ParentComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/listenToDoc.spec.js
+++ b/tests/specs/firestore/listenToDoc.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/listenToDoc.spec.js
+++ b/tests/specs/firestore/listenToDoc.spec.js
@@ -98,6 +98,34 @@ describe('listenToDoc()', function() {
       collectionRef.doc('testDoc').set(dummyCollection[0]);
     });
 
+    it("listenToDoc()'s .then method gets invoked when the document changes", done => {
+      const ref = base.listenToDoc(`${collectionPath}/testDoc`, {
+        context: {},
+        then(data) {
+          expect(data).toEqual(dummyCollection[0]);
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
+    it('listenToDoc() accepts a document reference', done => {
+      const docRef = app
+        .firestore()
+        .collection('testCollection')
+        .doc('testDoc');
+      const ref = base.listenToDoc(docRef, {
+        context: {},
+        then(data) {
+          expect(data).toEqual(dummyCollection[0]);
+          base.removeBinding(ref);
+          done();
+        }
+      });
+      collectionRef.doc('testDoc').set(dummyCollection[0]);
+    });
+
     it("listenToDoc's .onFailure method gets invoked in the component context with error if permissions do not allow read", done => {
       const ref = base.listenToDoc('/readFail/testDoc', {
         context: this,

--- a/tests/specs/firestore/removeDoc.spec.js
+++ b/tests/specs/firestore/removeDoc.spec.js
@@ -1,0 +1,86 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('removeDoc()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+  });
+
+  afterAll(done => {
+    testApp.delete().then(done);
+  });
+
+  beforeEach(done => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+    seedCollection()
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  afterEach(done => {
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  function seedCollection() {
+    const docs = dummyCollection.map(doc => {
+      const docRef = collectionRef.doc(doc.id.toString());
+      return docRef.set(doc);
+    });
+    return Promise.all(docs);
+  }
+
+  describe('removeDoc', () => {
+    it('deletes a document from firestore', done => {
+      base
+        .removeDoc(`${collectionPath}/1`)
+        .then(() => {
+          return collectionRef
+            .doc('1')
+            .get()
+            .then(snapshot => {
+              expect(snapshot.exists).toEqual(false);
+              done();
+            });
+        })
+        .catch(err => done.fail(err));
+    });
+
+    it('rejects if you dont have write permissions', done => {
+      base
+        .removeDoc('writeFail/1')
+        .then(() => {
+          done.fail('promise should reject');
+        })
+        .catch(err => {
+          expect(err).not.toBeNull();
+          done();
+        });
+    });
+  });
+});

--- a/tests/specs/firestore/removeDoc.spec.js
+++ b/tests/specs/firestore/removeDoc.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/removeDoc.spec.js
+++ b/tests/specs/firestore/removeDoc.spec.js
@@ -71,6 +71,25 @@ describe('removeDoc()', function() {
         .catch(err => done.fail(err));
     });
 
+    it('accepts a document reference', done => {
+      const docRef = app
+        .firestore()
+        .collection('testCollection')
+        .doc('1');
+      base
+        .removeDoc(docRef)
+        .then(() => {
+          return collectionRef
+            .doc('1')
+            .get()
+            .then(snapshot => {
+              expect(snapshot.exists).toEqual(false);
+              done();
+            });
+        })
+        .catch(err => done.fail(err));
+    });
+
     it('rejects if you dont have write permissions', done => {
       base
         .removeDoc('writeFail/1')

--- a/tests/specs/firestore/removeFromCollection.spec.js
+++ b/tests/specs/firestore/removeFromCollection.spec.js
@@ -95,6 +95,26 @@ describe('removeCollection()', function() {
       .catch(err => done.fail(err));
   });
 
+  it('accepts a collection reference', done => {
+    const testRef = app.firestore().collection('testCollection');
+    base
+      .removeFromCollection(testRef, {
+        query: ref =>
+          ref
+            .where('id', '<', 5)
+            .where('id', '>', 2)
+            .orderBy('id')
+      })
+      .then(() => {
+        collectionRef.get().then(snapshot => {
+          expect(snapshot.empty).toBe(false);
+          expect(snapshot.docs.length).toBe(3);
+          done();
+        });
+      })
+      .catch(err => done.fail(err));
+  });
+
   it('is a noop if no documents match query', done => {
     base
       .removeFromCollection(collectionPath, {

--- a/tests/specs/firestore/removeFromCollection.spec.js
+++ b/tests/specs/firestore/removeFromCollection.spec.js
@@ -94,4 +94,18 @@ describe('removeCollection()', function() {
       })
       .catch(err => done.fail(err));
   });
+
+  it('is a noop if no documents match query', done => {
+    base
+      .removeFromCollection(collectionPath, {
+        query: ref => ref.where('id', '>', 5).orderBy('id')
+      })
+      .then(() => {
+        collectionRef.get().then(snapshot => {
+          expect(snapshot.empty).toBe(false);
+          expect(snapshot.docs.length).toBe(5);
+          done();
+        });
+      });
+  });
 });

--- a/tests/specs/firestore/removeFromCollection.spec.js
+++ b/tests/specs/firestore/removeFromCollection.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/removeFromCollection.spec.js
+++ b/tests/specs/firestore/removeFromCollection.spec.js
@@ -1,0 +1,97 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('removeCollection()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+  });
+
+  afterAll(done => {
+    testApp.delete().then(done);
+  });
+
+  beforeEach(done => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+    seedCollection().then(done);
+  });
+
+  afterEach(done => {
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  function seedCollection() {
+    const docs = dummyCollection.map(doc => {
+      return collectionRef.add(doc);
+    });
+    return Promise.all(docs);
+  }
+
+  it('validates paths', done => {
+    try {
+      base.removeFromCollection('testCollection/doc');
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_ENDPOINT');
+      done();
+    }
+  });
+
+  it('removes all the documents from a collection', done => {
+    base
+      .removeFromCollection(collectionPath)
+      .then(() => {
+        collectionRef
+          .get()
+          .then(snapshot => {
+            expect(snapshot.empty).toBe(true);
+            done();
+          })
+          .catch(err => done.fail(err));
+      })
+      .catch(err => done.fail(err));
+  });
+
+  it('removes documents that match a query', done => {
+    base
+      .removeFromCollection(collectionPath, {
+        query: ref =>
+          ref
+            .where('id', '<', 5)
+            .where('id', '>', 2)
+            .orderBy('id')
+      })
+      .then(() => {
+        collectionRef.get().then(snapshot => {
+          expect(snapshot.empty).toBe(false);
+          expect(snapshot.docs.length).toBe(3);
+          done();
+        });
+      })
+      .catch(err => done.fail(err));
+  });
+});

--- a/tests/specs/firestore/reset.spec.js
+++ b/tests/specs/firestore/reset.spec.js
@@ -1,0 +1,118 @@
+const Rebase = require('../../../src/rebase.js');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var dummyArrayOfObjects = require('../../fixtures/dummyArrayOfObjects');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var dummyArrData = require('../../fixtures/dummyArrData');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('reset()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  it('should remove listeners set by the app', done => {
+    class TestComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          user: {}
+        };
+      }
+      componentDidMount() {
+        this.ref = base.bindCollection(`${collectionPath}`, {
+          context: this,
+          state: 'user'
+        });
+        base.reset();
+        collectionRef
+          .doc('testDoc')
+          .set({ user: 'abcdef' })
+          .then(() => {
+            setTimeout(done, 500);
+          });
+      }
+      componentDidUpdate() {
+        done.fail('listener should have been removed');
+      }
+      render() {
+        return <div>No Data</div>;
+      }
+    }
+    ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+  });
+
+  it('should remove syncs set by the app', done => {
+    class TestComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          user: {}
+        };
+      }
+      componentDidMount() {
+        this.ref = base.syncDoc(`${collectionPath}/testDoc`, {
+          context: this,
+          state: 'user'
+        });
+        base.reset();
+        collectionRef
+          .doc('testDoc')
+          .set({ user: 'abcdef' })
+          .then(() => {
+            setTimeout(done, 500);
+          });
+      }
+      componentDidUpdate() {
+        done.fail('Sync should have been removed');
+      }
+      render() {
+        return <div>No Data</div>;
+      }
+    }
+    ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/reset.spec.js
+++ b/tests/specs/firestore/reset.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../src/rebase.js');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/syncDoc.spec.js
+++ b/tests/specs/firestore/syncDoc.spec.js
@@ -39,6 +39,7 @@ describe('syncDoc()', function() {
   });
 
   afterEach(done => {
+    ReactDOM.unmountComponentAtNode(document.body);
     Promise.all([
       collectionRef.get().then(docs => {
         const deleteOps = [];
@@ -301,7 +302,7 @@ describe('syncDoc()', function() {
         });
     });
 
-    it('syncDoc() syncs its local state with Firebase', done => {
+    it('syncDoc() syncs its local state with Firestore', done => {
       class TestComponent extends React.Component {
         constructor(props) {
           super(props);

--- a/tests/specs/firestore/syncDoc.spec.js
+++ b/tests/specs/firestore/syncDoc.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/syncDoc.spec.js
+++ b/tests/specs/firestore/syncDoc.spec.js
@@ -1,0 +1,845 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var dummyArrayOfObjects = require('../../fixtures/dummyArrayOfObjects');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var dummyArrData = require('../../fixtures/dummyArrData');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('syncDoc()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+    var mountNode = document.createElement('div');
+    mountNode.setAttribute('id', 'mount');
+    document.body.appendChild(mountNode);
+  });
+
+  afterAll(done => {
+    var mountNode = document.getElementById('mount');
+    mountNode.parentNode.removeChild(mountNode);
+    testApp.delete().then(done);
+  });
+
+  beforeEach(() => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+  });
+
+  afterEach(done => {
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  it('syncDoc() validates document paths', done => {
+    try {
+      base.syncDoc('collection', {
+        context: { setState: () => {} },
+        state: 'prop',
+        then() {
+          done.fail('error should have been thrown');
+        }
+      });
+    } catch (err) {
+      expect(err).not.toBe(null);
+      done();
+    }
+  });
+
+  it('syncDoc() throws an error when context is missing from options', function() {
+    var invalidOptions = [
+      [],
+      {},
+      { context: undefined },
+      { context: 'strNotObj' },
+      { context: window }
+    ];
+    invalidOptions.forEach(option => {
+      try {
+        base.syncDoc('testCollection/testDoc', option);
+      } catch (err) {
+        expect(err.code).toEqual('INVALID_OPTIONS');
+      }
+    });
+  });
+
+  it('syncDoc() throws an error when state is missing from options', function() {
+    var invalidOptions = [
+      [],
+      {},
+      { context: { setState: () => {} } },
+      { context: { setState: () => {} }, state: null },
+      { context: { setState: () => {} }, state: {} }
+    ];
+    invalidOptions.forEach(option => {
+      try {
+        base.syncDoc('testCollection/testDoc', option);
+      } catch (err) {
+        expect(err.code).toEqual('INVALID_OPTIONS');
+      }
+    });
+  });
+
+  describe('Async tests', function() {
+    it('syncDoc() supports syncing of multiple keys', done => {
+      var counter = 0;
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            one: {},
+            two: {},
+            three: {}
+          };
+        }
+
+        componentDidMount() {
+          base.syncDoc(`${collectionPath}/docOne`, {
+            context: this,
+            state: 'one',
+            then() {
+              counter++;
+              this.checkDone();
+            }
+          });
+
+          base.syncDoc(`${collectionPath}/docTwo`, {
+            context: this,
+            state: 'two',
+            then() {
+              counter++;
+              this.checkDone();
+            }
+          });
+
+          base.syncDoc(`${collectionPath}/docThree`, {
+            context: this,
+            state: 'three',
+            then() {
+              counter++;
+              this.checkDone();
+            }
+          });
+
+          this.unsubscribe1 = collectionRef
+            .doc(`docOne`)
+            .onSnapshot(snapshot => {
+              if (snapshot.exists) {
+                expect(snapshot.data()).toEqual({ name: 'Doc 1' });
+                expect(this.state.one).toEqual({ name: 'Doc 1' });
+                counter++;
+                this.checkDone();
+              }
+            });
+
+          this.unsubscribe2 = collectionRef
+            .doc(`docTwo`)
+            .onSnapshot(snapshot => {
+              if (snapshot.exists) {
+                expect(snapshot.data()).toEqual({ name: 'Doc 2' });
+                expect(this.state.two).toEqual({ name: 'Doc 2' });
+                counter++;
+                this.checkDone();
+              }
+            });
+
+          this.unsubscribe3 = collectionRef
+            .doc(`docThree`)
+            .onSnapshot(snapshot => {
+              if (snapshot.exists) {
+                expect(snapshot.data()).toEqual({ name: 'Doc 3' });
+                expect(this.state.three).toEqual({ name: 'Doc 3' });
+                counter++;
+                this.checkDone();
+              }
+            });
+
+          this.setState({
+            one: {
+              name: 'Doc 1'
+            },
+            two: {
+              name: 'Doc 2'
+            },
+            three: {
+              name: 'Doc 3'
+            }
+          });
+        }
+        checkDone() {
+          if (counter === 6) {
+            this.unsubscribe1();
+            this.unsubscribe2();
+            this.unsubscribe3();
+            ReactDOM.unmountComponentAtNode(document.getElementById('mount'));
+            done();
+          }
+        }
+
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc() should only run synced keys through their respective update function', done => {
+      var counter = 0;
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            one: 0,
+            two: 0,
+            three: 0
+          };
+        }
+
+        componentDidMount() {
+          base.syncDoc(`${collectionPath}/one`, {
+            context: this,
+            state: 'one'
+          });
+
+          base.syncDoc(`${collectionPath}/two`, {
+            context: this,
+            state: 'two'
+          });
+          this.setState({
+            one: { key1: 'one', key2: 'value' },
+            two: { key1: 'two', key2: 'value' },
+            three: {
+              key1: 'three',
+              key2: firebase.firestore.FieldValue.serverTimestamp
+            }
+          });
+          setTimeout(() => {
+            this.checkDone();
+          }, 300);
+        }
+
+        checkDone() {
+          expect(this.state.one).toEqual({
+            key1: 'one',
+            key2: 'value'
+          });
+          expect(this.state.two).toEqual({
+            key1: 'two',
+            key2: 'value'
+          });
+          expect(this.state.three).toEqual({
+            key1: 'three',
+            key2: firebase.firestore.FieldValue.serverTimestamp
+          });
+          done();
+        }
+
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc() synced documents can be swapped out during lifecycle', done => {
+      collectionRef
+        .doc('child2')
+        .set(dummyObjData)
+        .then(() => {
+          class TestComponent extends React.Component {
+            constructor(props) {
+              super(props);
+              this.state = {
+                data: []
+              };
+            }
+            componentWillMount() {
+              this.ref = base.syncDoc(`${collectionPath}/child1`, {
+                context: this,
+                state: 'data'
+              });
+            }
+            componentDidMount() {
+              base.removeBinding(this.ref);
+              base.syncDoc(`${collectionPath}/child2`, {
+                context: this,
+                state: 'data'
+              });
+            }
+            componentDidUpdate() {
+              expect(this.state.data).toEqual(dummyObjData);
+              ReactDOM.unmountComponentAtNode(document.body);
+              done();
+            }
+            render() {
+              return <div>No Data</div>;
+            }
+          }
+          ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+        });
+    });
+
+    it('syncDoc() syncs its local state with Firebase', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: {}
+          };
+        }
+        componentWillMount() {
+          base.syncDoc(`${collectionPath}/userData`, {
+            context: this,
+            state: 'user'
+          });
+        }
+        componentDidMount() {
+          this.setState({
+            user: { name: 'Tyler' }
+          });
+        }
+
+        componentDidUpdate() {
+          const unsubscribe = collectionRef.doc('userData').onSnapshot(doc => {
+            if (doc.exists) {
+              const data = doc.data();
+              expect(data).toEqual(this.state.user);
+              expect(data).toEqual({ name: 'Tyler' });
+              ReactDOM.unmountComponentAtNode(document.body);
+              unsubscribe();
+              done();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc invokes .then with correct context when the initial listener is set', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            loading: true,
+            user: {}
+          };
+        }
+        componentDidMount() {
+          var context = this;
+          base.syncDoc(`${collectionPath}/userData`, {
+            context: this,
+            state: 'user',
+            then() {
+              this.setState(
+                {
+                  loading: false
+                },
+                () => {
+                  expect(this.state.loading).toEqual(false);
+                  expect(this).toEqual(context);
+                  ReactDOM.unmountComponentAtNode(document.body);
+                  done();
+                }
+              );
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc functions properly with a nested object data structure', done => {
+      var nestedObj = {
+        name: 'Tyler',
+        age: 25,
+        friends: ['Joey', 'Mikenzi', 'Jacob'],
+        foo: {
+          bar: 'bar',
+          foobar: 'barfoo'
+        }
+      };
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: {}
+          };
+        }
+        componentWillMount() {
+          this.ref = base.syncDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'user'
+          });
+        }
+        componentDidMount() {
+          this.setState({
+            user: nestedObj
+          });
+        }
+        componentDidUpdate() {
+          const unsubscribe = collectionRef.doc('testDoc').onSnapshot(doc => {
+            if (doc.exists) {
+              const data = doc.data();
+              expect(data).toEqual(this.state.user);
+              expect(data).toEqual(nestedObj);
+              ReactDOM.unmountComponentAtNode(document.body);
+              unsubscribe();
+              done();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc syncs and converts server timestamps', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: {}
+          };
+        }
+        componentDidMount() {
+          base.syncDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'user'
+          });
+          this.setState({
+            user: {
+              name: 'Al',
+              timestamp: firebase.firestore.FieldValue.serverTimestamp()
+            }
+          });
+        }
+        componentWillUpdate(nextProps, nextState) {
+          if (nextState.user.timestamp) {
+            expect(this.state.user.timestamp).toEqual(jasmine.any(Date));
+            ReactDOM.unmountComponentAtNode(document.body);
+            done();
+          }
+        }
+        render() {
+          return <div>IQ</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc syncs and converts server timestamps in a nested data structure', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: []
+          };
+        }
+        componentWillMount() {
+          base.syncDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'user'
+          });
+        }
+        componentDidMount() {
+          this.setState({
+            user: {
+              name: 'Al',
+              timestamp: firebase.firestore.FieldValue.serverTimestamp()
+            }
+          });
+        }
+        componentWillUpdate(nextProps, nextState) {
+          if (this.state.user.timestamp) {
+            expect(this.state.user.timestamp).toEqual(jasmine.any(Date));
+            ReactDOM.unmountComponentAtNode(document.body);
+            done();
+          }
+        }
+        render() {
+          return <div>IQ</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc should allow multiple components to sync changes to the same endpoint', done => {
+      function cleanUp(done) {
+        ReactDOM.unmountComponentAtNode(document.getElementById('div1'));
+        ReactDOM.unmountComponentAtNode(document.getElementById('div2'));
+        done();
+      }
+
+      //set up mount points
+      var div1 = document.createElement('div');
+      div1.setAttribute('id', 'div1');
+
+      var div2 = document.createElement('div');
+      div2.setAttribute('id', 'div2');
+      document.body.appendChild(div1);
+      document.body.appendChild(div2);
+
+      var component1DidUpdate = false;
+      var component2DidUpdate = false;
+
+      class TestComponent1 extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            doc: {
+              friends: []
+            }
+          };
+        }
+        componentDidMount() {
+          this.ref = base.syncDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'doc'
+          });
+          this.setState({
+            doc: {
+              friends: dummyArrData
+            }
+          });
+        }
+        componentDidUpdate() {
+          const unsubscribe = collectionRef.doc('testDoc').onSnapshot(doc => {
+            if (doc.exists) {
+              var data = doc.data();
+              expect(data).toEqual(this.state.doc);
+              expect(data.friends).toEqual(dummyArrData);
+              component1DidUpdate = true;
+              if (component1DidUpdate && component2DidUpdate) {
+                cleanUp(done);
+              }
+              unsubscribe();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      class TestComponent2 extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            friends: []
+          };
+        }
+        componentDidMount() {
+          base.syncDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'friends'
+          });
+          this.setState({
+            doc: {
+              friends: dummyArrData
+            }
+          });
+        }
+        componentDidUpdate() {
+          const unsubscribe = collectionRef.doc('testDoc').onSnapshot(doc => {
+            if (doc.exists) {
+              var data = doc.data();
+              expect(data).toEqual(this.state.doc);
+              expect(data.friends).toEqual(dummyArrData);
+              component2DidUpdate = true;
+              if (component1DidUpdate && component2DidUpdate) {
+                cleanUp(done);
+              }
+              unsubscribe();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent1 />, document.getElementById('div1'));
+      ReactDOM.render(<TestComponent2 />, document.getElementById('div2'));
+    });
+
+    it('syncDoc should not call unbound sync listeners after removeBinding called', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            doc: {
+              friends: []
+            }
+          };
+        }
+        componentDidMount() {
+          this.ref = base.syncDoc(`${collectionPath}/testDoc1`, {
+            context: this,
+            state: 'doc'
+          });
+          this.otherRef = base.syncDoc(`${collectionPath}/testDoc2`, {
+            context: this,
+            state: 'doc'
+          });
+          base.removeBinding(this.ref);
+          this.setState({
+            doc: {
+              friends: dummyArrData
+            }
+          });
+        }
+        componentDidUpdate() {
+          const unsubscribe = collectionRef.doc('testDoc2').onSnapshot(doc2 => {
+            if (doc2.exists) {
+              expect(doc2.data().friends).toEqual(dummyArrData);
+              const unsubscribe2 = collectionRef
+                .doc('testDoc1')
+                .onSnapshot(doc1 => {
+                  expect(doc1.exists).toBe(false);
+                  unsubscribe();
+                  unsubscribe2();
+                  done();
+                });
+            }
+          });
+        }
+        render() {
+          return <div />;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncDoc should reset setState after all listeners are unbound', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            friends: []
+          };
+        }
+        componentDidMount() {
+          this.ref = base.syncDoc(`${collectionPath}/testDoc`, {
+            context: this,
+            state: 'friends',
+            asArray: true
+          });
+          base.removeBinding(this.ref);
+          this.setState({
+            friends: {
+              list: ['Chris']
+            }
+          });
+        }
+        componentDidUpdate() {
+          expect(this.state.friends.list).toEqual(['Chris']);
+          done();
+        }
+        render() {
+          return (
+            <div>
+              Name: {this.state.name} <br />
+              Age: {this.state.age}
+            </div>
+          );
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+  });
+
+  it('listeners are removed when component unmounts', done => {
+    spyOn(console, 'error');
+    var componentWillMountSpy = jasmine.createSpy('componentWillMountSpy');
+    class ChildComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {}
+        };
+      }
+
+      componentWillMount() {
+        base.syncDoc(`${collectionPath}/testDoc`, {
+          context: this,
+          state: 'data'
+        });
+      }
+
+      componentWillUnmount() {
+        componentWillMountSpy('additional clean up performed');
+      }
+
+      render() {
+        return (
+          <div>
+            Name: {this.state.name} <br />
+            Age: {this.state.age}
+          </div>
+        );
+      }
+    }
+
+    class ParentComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          showChild: true
+        };
+      }
+
+      setData(cb) {
+        this.setState(
+          {
+            data: dummyObjData
+          },
+          () => {
+            setTimeout(cb, 50);
+          }
+        );
+      }
+
+      componentDidMount() {
+        this.setState(
+          {
+            showChild: false
+          },
+          () => {
+            this.setData(() => {
+              expect(console.error).not.toHaveBeenCalled();
+              expect(componentWillMountSpy).toHaveBeenCalledWith(
+                'additional clean up performed'
+              );
+              done();
+            });
+          }
+        );
+      }
+
+      render() {
+        return <div>{this.state.showChild ? <ChildComponent /> : null}</div>;
+      }
+    }
+    ReactDOM.render(<ParentComponent />, document.getElementById('mount'));
+  });
+
+  it('setState callback is called', done => {
+    var callbackSpy = jasmine.createSpy('cb');
+    class TestComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {
+            count: 6
+          }
+        };
+      }
+
+      componentWillMount() {
+        base.syncDoc(`${collectionPath}/testDoc`, {
+          context: this,
+          state: 'data'
+        });
+      }
+
+      componentDidMount() {
+        this.setState(
+          {
+            data: {
+              count: 6
+            }
+          },
+          callbackSpy
+        );
+      }
+
+      componentDidUpdate() {
+        setTimeout(() => {
+          expect(callbackSpy).toHaveBeenCalled();
+          done();
+        }, 200);
+      }
+
+      render() {
+        return <div>{this.state.data.count}</div>;
+      }
+    }
+    ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+  });
+
+  it('syncs correctly when setState argument is a function', done => {
+    class TestComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: {
+            count: 5
+          }
+        };
+      }
+
+      componentWillMount() {
+        base.syncDoc(`${collectionPath}/testDoc`, {
+          context: this,
+          state: 'data'
+        });
+      }
+
+      componentDidMount() {
+        this.setState(
+          prevState => ({
+            data: {
+              count: prevState.data.count + 1
+            }
+          }),
+          () => {
+            expect(this.state.data.count).toEqual(6);
+            setTimeout(() => {
+              collectionRef
+                .doc('testDoc')
+                .get()
+                .then(doc => {
+                  var data = doc.data();
+                  expect(data.count).toEqual(6);
+                  done();
+                });
+            }, 1000);
+          }
+        );
+      }
+
+      render() {
+        return <div>{this.state.data.count}</div>;
+      }
+    }
+    ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+  });
+});

--- a/tests/specs/firestore/syncDoc.spec.js
+++ b/tests/specs/firestore/syncDoc.spec.js
@@ -341,6 +341,46 @@ describe('syncDoc()', function() {
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('syncDoc() works with setState as a function', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: {},
+            other: 'state'
+          };
+        }
+        componentWillMount() {
+          base.syncDoc(`${collectionPath}/userData`, {
+            context: this,
+            state: 'user'
+          });
+        }
+        componentDidMount() {
+          this.setState(currentState =>
+            Object.assign(currentState, { user: { name: 'Tyler' } })
+          );
+        }
+
+        componentDidUpdate() {
+          const unsubscribe = collectionRef.doc('userData').onSnapshot(doc => {
+            if (doc.exists) {
+              const data = doc.data();
+              expect(data).toEqual(this.state.user);
+              expect(data).toEqual({ name: 'Tyler' });
+              ReactDOM.unmountComponentAtNode(document.body);
+              unsubscribe();
+              done();
+            }
+          });
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
     it('syncDoc invokes .then with correct context when the initial listener is set', done => {
       class TestComponent extends React.Component {
         constructor(props) {

--- a/tests/specs/firestore/updateDoc.spec.js
+++ b/tests/specs/firestore/updateDoc.spec.js
@@ -80,6 +80,28 @@ describe('updateDoc()', function() {
       .catch(err => done.fail(err));
   });
 
+  it('accepts a document reference', done => {
+    const docRef = app
+      .firestore()
+      .collection('testCollection')
+      .doc('doc-1');
+    base
+      .updateDoc(docRef, {
+        name: 'Updated Document'
+      })
+      .then(() => {
+        collectionRef
+          .doc('doc-1')
+          .get()
+          .then(doc => {
+            const data = doc.data();
+            expect(data.name).toEqual('Updated Document');
+            done();
+          });
+      })
+      .catch(err => done.fail(err));
+  });
+
   it('errors on permission fail', done => {
     base
       .updateDoc(`readFail/doc-1`, {

--- a/tests/specs/firestore/updateDoc.spec.js
+++ b/tests/specs/firestore/updateDoc.spec.js
@@ -1,4 +1,4 @@
-const Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 const React = require('react');
 const ReactDOM = require('react-dom');
 const firebase = require('firebase');

--- a/tests/specs/firestore/updateDoc.spec.js
+++ b/tests/specs/firestore/updateDoc.spec.js
@@ -1,0 +1,96 @@
+const Rebase = require('../../../dist/bundle');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const firebase = require('firebase');
+require('firebase/firestore');
+
+var dummyCollection = require('../../fixtures/dummyCollection');
+var firebaseConfig = require('../../fixtures/config');
+
+describe('updateDoc()', function() {
+  var base;
+  var testApp;
+  var collectionPath = 'testCollection';
+  var collectionRef;
+  var app;
+
+  beforeAll(() => {
+    testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
+    collectionRef = testApp.firestore().collection(collectionPath);
+  });
+
+  afterAll(done => {
+    testApp.delete().then(done);
+  });
+
+  beforeEach(done => {
+    app = firebase.initializeApp(firebaseConfig);
+    var db = firebase.firestore(app);
+    base = Rebase.createClass(db);
+    seedCollection().then(done);
+  });
+
+  afterEach(done => {
+    Promise.all([
+      collectionRef.get().then(docs => {
+        const deleteOps = [];
+        docs.forEach(doc => {
+          deleteOps.push(doc.ref.delete());
+        });
+        return Promise.all(deleteOps);
+      }),
+      app.delete()
+    ])
+      .then(done)
+      .catch(err => done.fail(err));
+  });
+
+  function seedCollection() {
+    const docs = dummyCollection.map(doc => {
+      const docRef = collectionRef.doc(`doc-${doc.id}`);
+      return docRef.set(doc);
+    });
+    return Promise.all(docs);
+  }
+
+  it('it throws an error given a invalid endpoint', done => {
+    try {
+      base.updateDoc('collection', { key: 'value' });
+    } catch (err) {
+      expect(err.code).toEqual('INVALID_ENDPOINT');
+      done();
+    }
+  });
+
+  it('updates a document', done => {
+    base
+      .updateDoc(`${collectionPath}/doc-1`, {
+        name: 'Updated Document'
+      })
+      .then(() => {
+        collectionRef
+          .doc('doc-1')
+          .get()
+          .then(doc => {
+            const data = doc.data();
+            expect(data.name).toEqual('Updated Document');
+            done();
+          });
+      })
+      .catch(err => done.fail(err));
+  });
+
+  it('errors on permission fail', done => {
+    base
+      .updateDoc(`readFail/doc-1`, {
+        name: 'Updated Document'
+      })
+      .then(() => {
+        done.fail('should reject');
+      })
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        done();
+      });
+  });
+});

--- a/tests/specs/rtdb/bindToState.spec.js
+++ b/tests/specs/rtdb/bindToState.spec.js
@@ -1,14 +1,14 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');
 require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var invalidOptions = require('../fixtures/invalidOptions');
-var dummyArrData = require('../fixtures/dummyArrData');
-var firebaseConfig = require('../fixtures/config');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var dummyArrData = require('../../fixtures/dummyArrData');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('bindToState()', function() {
   var base;

--- a/tests/specs/rtdb/bindToState.spec.js
+++ b/tests/specs/rtdb/bindToState.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');

--- a/tests/specs/rtdb/bindToState.spec.js
+++ b/tests/specs/rtdb/bindToState.spec.js
@@ -6,6 +6,7 @@ require('firebase/database');
 
 var invalidEndpoints = require('../../fixtures/invalidEndpoints');
 var dummyObjData = require('../../fixtures/dummyObjData');
+var dummyArrayOfObjects = require('../../fixtures/dummyArrayOfObjects');
 var invalidOptions = require('../../fixtures/invalidOptions');
 var dummyArrData = require('../../fixtures/dummyArrData');
 var firebaseConfig = require('../../fixtures/config');
@@ -435,6 +436,40 @@ describe('bindToState()', function() {
       ReactDOM.render(<TestComponent1 />, document.getElementById('div1'));
       ReactDOM.render(<TestComponent2 />, document.getElementById('div2'));
     });
+  });
+
+  it('works with queries', done => {
+    class TestComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          data: []
+        };
+      }
+      componentWillMount() {
+        this.ref = base.bindToState(testEndpoint, {
+          context: this,
+          state: 'data',
+          asArray: true,
+          queries: {
+            limitToLast: 1,
+            orderByChild: 'name',
+            equalTo: 'Tyler'
+          }
+        });
+      }
+      componentDidMount() {
+        ref.child(testEndpoint).set(dummyArrayOfObjects);
+      }
+      componentDidUpdate() {
+        expect(this.state.data).toEqual([{ key: '0', name: 'Tyler' }]);
+        done();
+      }
+      render() {
+        return <div>No Data</div>;
+      }
+    }
+    ReactDOM.render(<TestComponent />, document.getElementById('mount'));
   });
 
   it('listeners are removed when component unmounts', done => {

--- a/tests/specs/rtdb/fetch.spec.js
+++ b/tests/specs/rtdb/fetch.spec.js
@@ -1,16 +1,16 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');
 require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var dummyNestedObjData = require('../fixtures/dummyNestedObjData');
-var invalidOptions = require('../fixtures/invalidOptions');
-var firebaseConfig = require('../fixtures/config');
-var nestedObjArrResult = require('../fixtures/nestedObjArrResult');
-var dummyArrData = require('../fixtures/dummyArrData');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var dummyNestedObjData = require('../../fixtures/dummyNestedObjData');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var firebaseConfig = require('../../fixtures/config');
+var nestedObjArrResult = require('../../fixtures/nestedObjArrResult');
+var dummyArrData = require('../../fixtures/dummyArrData');
 
 describe('fetch()', function() {
   var base;

--- a/tests/specs/rtdb/fetch.spec.js
+++ b/tests/specs/rtdb/fetch.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase/app');

--- a/tests/specs/rtdb/fetch.spec.js
+++ b/tests/specs/rtdb/fetch.spec.js
@@ -171,6 +171,14 @@ describe('fetch()', function() {
         });
     });
 
+    it('fetch() calls onFailure callback if present', done => {
+      const spy = jasmine.createSpy();
+      base.fetch('/readFail', { context: {}, onFailure: spy }).then(() => {
+        expect(spy.calls.count()).toEqual(1);
+        done();
+      });
+    });
+
     it('fetch() correctly updates the state of the component with data from fetch', done => {
       var testApp = firebase.initializeApp(firebaseConfig, 'DB_CHECK');
       var ref = testApp.database().ref();

--- a/tests/specs/rtdb/fetch.spec.js
+++ b/tests/specs/rtdb/fetch.spec.js
@@ -7,6 +7,7 @@ require('firebase/database');
 var invalidEndpoints = require('../../fixtures/invalidEndpoints');
 var dummyObjData = require('../../fixtures/dummyObjData');
 var dummyNestedObjData = require('../../fixtures/dummyNestedObjData');
+var dummyArrayOfObjects = require('../../fixtures/dummyArrayOfObjects');
 var invalidOptions = require('../../fixtures/invalidOptions');
 var firebaseConfig = require('../../fixtures/config');
 var nestedObjArrResult = require('../../fixtures/nestedObjArrResult');
@@ -233,6 +234,47 @@ describe('fetch()', function() {
         }
         componentDidUpdate() {
           expect(this.state.friends).toEqual([25, 'Tyler McGinnis']);
+          done();
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('works with queries', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            data: []
+          };
+        }
+        componentWillMount() {
+          this.ref = base.fetch(testEndpoint, {
+            context: this,
+            asArray: true,
+            queries: {
+              limitToLast: 1,
+              orderByChild: 'name',
+              equalTo: 'Tyler'
+            },
+            then(data) {
+              this.setState({
+                data: data
+              });
+            }
+          });
+        }
+        componentDidMount() {
+          app
+            .database()
+            .ref(testEndpoint)
+            .set(dummyArrayOfObjects);
+        }
+        componentDidUpdate() {
+          expect(this.state.data).toEqual([{ key: '0', name: 'Tyler' }]);
           done();
         }
         render() {

--- a/tests/specs/rtdb/listenTo.spec.js
+++ b/tests/specs/rtdb/listenTo.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');

--- a/tests/specs/rtdb/listenTo.spec.js
+++ b/tests/specs/rtdb/listenTo.spec.js
@@ -1,13 +1,13 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');
 var database = require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var invalidOptions = require('../fixtures/invalidOptions');
-var firebaseConfig = require('../fixtures/config');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('listenTo()', function() {
   var base;

--- a/tests/specs/rtdb/post.spec.js
+++ b/tests/specs/rtdb/post.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');

--- a/tests/specs/rtdb/post.spec.js
+++ b/tests/specs/rtdb/post.spec.js
@@ -1,13 +1,13 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');
 var database = require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var invalidOptions = require('../fixtures/invalidOptions');
-var firebaseConfig = require('../fixtures/config');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('post()', function() {
   var base;

--- a/tests/specs/rtdb/push.spec.js
+++ b/tests/specs/rtdb/push.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');

--- a/tests/specs/rtdb/push.spec.js
+++ b/tests/specs/rtdb/push.spec.js
@@ -1,13 +1,13 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');
 var database = require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var invalidOptions = require('../fixtures/invalidOptions');
-var firebaseConfig = require('../fixtures/config');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('push()', function() {
   var base;

--- a/tests/specs/rtdb/remove.spec.js
+++ b/tests/specs/rtdb/remove.spec.js
@@ -1,7 +1,7 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var firebase = require('firebase');
-var firebaseConfig = require('../fixtures/config');
-var dummyObjData = require('../fixtures/dummyObjData');
+var firebaseConfig = require('../../fixtures/config');
+var dummyObjData = require('../../fixtures/dummyObjData');
 var database = require('firebase/database');
 
 describe('remove()', function() {

--- a/tests/specs/rtdb/remove.spec.js
+++ b/tests/specs/rtdb/remove.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var firebase = require('firebase');
 var firebaseConfig = require('../../fixtures/config');
 var dummyObjData = require('../../fixtures/dummyObjData');

--- a/tests/specs/rtdb/removeBinding.spec.js
+++ b/tests/specs/rtdb/removeBinding.spec.js
@@ -1,9 +1,9 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var firebase = require('firebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
-var firebaseConfig = require('../fixtures/config');
-var dummyObjData = require('../fixtures/dummyObjData');
+var firebaseConfig = require('../../fixtures/config');
+var dummyObjData = require('../../fixtures/dummyObjData');
 var database = require('firebase/database');
 
 describe('removeBinding()', function() {

--- a/tests/specs/rtdb/removeBinding.spec.js
+++ b/tests/specs/rtdb/removeBinding.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var firebase = require('firebase');
 var React = require('react');
 var ReactDOM = require('react-dom');

--- a/tests/specs/rtdb/reset.spec.js
+++ b/tests/specs/rtdb/reset.spec.js
@@ -1,9 +1,9 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var firebase = require('firebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
-var firebaseConfig = require('../fixtures/config');
-var dummyObjData = require('../fixtures/dummyObjData');
+var firebaseConfig = require('../../fixtures/config');
+var dummyObjData = require('../../fixtures/dummyObjData');
 var database = require('firebase/database');
 
 describe('reset()', function() {

--- a/tests/specs/rtdb/reset.spec.js
+++ b/tests/specs/rtdb/reset.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var firebase = require('firebase');
 var React = require('react');
 var ReactDOM = require('react-dom');

--- a/tests/specs/rtdb/serverinfo.spec.js
+++ b/tests/specs/rtdb/serverinfo.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var firebase = require('firebase');
 var database = require('firebase/database');
 

--- a/tests/specs/rtdb/serverinfo.spec.js
+++ b/tests/specs/rtdb/serverinfo.spec.js
@@ -1,8 +1,8 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var firebase = require('firebase');
 var database = require('firebase/database');
 
-var firebaseConfig = require('../fixtures/config');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('Firebase Server Info', function() {
   var base;

--- a/tests/specs/rtdb/syncState.spec.js
+++ b/tests/specs/rtdb/syncState.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');

--- a/tests/specs/rtdb/syncState.spec.js
+++ b/tests/specs/rtdb/syncState.spec.js
@@ -419,6 +419,76 @@ describe('syncState()', function() {
       ReactDOM.render(<TestComponent />, document.getElementById('mount'));
     });
 
+    it('syncState() works with setState as a function', done => {
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: {}
+          };
+        }
+        componentWillMount() {
+          this.ref = base.syncState(`${testEndpoint}/userData`, {
+            context: this,
+            state: 'user'
+          });
+        }
+        componentDidMount() {
+          this.setState(currentState => {
+            return Object.assign(currentState, {
+              user: { name: 'Tyler' }
+            });
+          });
+          setTimeout(() => {
+            ref.child(`${testEndpoint}/userData`).once('value', snapshot => {
+              var data = snapshot.val();
+              expect(data).toEqual(this.state.user);
+              expect(data).toEqual({ name: 'Tyler' });
+              ReactDOM.unmountComponentAtNode(document.body);
+              done();
+            });
+          }, 500);
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
+    it('syncState() setState callback is called when setState is a function', done => {
+      const spy = jasmine.createSpy();
+      class TestComponent extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            user: {}
+          };
+        }
+        componentWillMount() {
+          this.ref = base.syncState(`${testEndpoint}/userData`, {
+            context: this,
+            state: 'user'
+          });
+        }
+        componentDidMount() {
+          this.setState(currentState => {
+            return Object.assign(currentState, {
+              user: { name: 'Tyler' }
+            });
+          }, spy);
+          setTimeout(() => {
+            expect(spy.calls.count()).toEqual(1);
+            done();
+          }, 100);
+        }
+        render() {
+          return <div>No Data</div>;
+        }
+      }
+      ReactDOM.render(<TestComponent />, document.getElementById('mount'));
+    });
+
     it('syncState() syncs its local state with Firebase when the provided state string points to a nested object', done => {
       class TestComponent extends React.Component {
         constructor(props) {

--- a/tests/specs/rtdb/syncState.spec.js
+++ b/tests/specs/rtdb/syncState.spec.js
@@ -1,15 +1,15 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');
 require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var dummyArrayOfObjects = require('../fixtures/dummyArrayOfObjects');
-var invalidOptions = require('../fixtures/invalidOptions');
-var dummyArrData = require('../fixtures/dummyArrData');
-var firebaseConfig = require('../fixtures/config');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var dummyArrayOfObjects = require('../../fixtures/dummyArrayOfObjects');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var dummyArrData = require('../../fixtures/dummyArrData');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('syncState()', function() {
   var base;

--- a/tests/specs/rtdb/update.spec.js
+++ b/tests/specs/rtdb/update.spec.js
@@ -1,4 +1,4 @@
-var Rebase = require('../../../dist/bundle');
+const Rebase = require('../../../src/rebase');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');

--- a/tests/specs/rtdb/update.spec.js
+++ b/tests/specs/rtdb/update.spec.js
@@ -1,13 +1,13 @@
-var Rebase = require('../../dist/bundle');
+var Rebase = require('../../../dist/bundle');
 var React = require('react');
 var ReactDOM = require('react-dom');
 var firebase = require('firebase');
 var database = require('firebase/database');
 
-var invalidEndpoints = require('../fixtures/invalidEndpoints');
-var dummyObjData = require('../fixtures/dummyObjData');
-var invalidOptions = require('../fixtures/invalidOptions');
-var firebaseConfig = require('../fixtures/config');
+var invalidEndpoints = require('../../fixtures/invalidEndpoints');
+var dummyObjData = require('../../fixtures/dummyObjData');
+var invalidOptions = require('../../fixtures/invalidOptions');
+var firebaseConfig = require('../../fixtures/config');
 
 describe('update()', function() {
   var base;

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -52,6 +52,13 @@ describe('utils', () => {
       expect(result.length).toEqual(1);
       expect(result[0]).toEqual({ key1: { nKey1: 'value' }, key: 'key1' });
     });
+
+    it('should return an array from a snapshot that is a scalar value', () => {
+      var snapshot = mockSnapshot(5);
+      var result = utils._toArray(snapshot);
+      expect(result.length).toEqual(1);
+      expect(result[0]).toEqual(5);
+    });
   });
 
   describe('_isValid', () => {
@@ -145,6 +152,18 @@ describe('utils', () => {
           }
         }
       };
+      var result = utils._getNestedObject(fakeObj, 'foo.bar.nope');
+      expect(result).toBeUndefined();
+    });
+
+    it('should be a noop if not a nested path', () => {
+      var fakeObj = {};
+      var result = utils._getNestedObject(fakeObj, 'foo');
+      expect(result).toBeUndefined();
+    });
+
+    it('should be a noop if not a nested obj', () => {
+      var fakeObj = {};
       var result = utils._getNestedObject(fakeObj, 'foo.bar.nope');
       expect(result).toBeUndefined();
     });
@@ -413,7 +432,8 @@ describe('utils', () => {
         'orderByChild',
         'startAt',
         'endAt',
-        'equalTo'
+        'equalTo',
+        'orderByPriority'
       ]);
       ref.limitToFirst.and.returnValue(ref);
       ref.limitToLast.and.returnValue(ref);
@@ -427,7 +447,8 @@ describe('utils', () => {
         startAt: 4,
         endAt: 1,
         orderByChild: 'value',
-        limitToFirst: 3
+        limitToFirst: 3,
+        orderByPriority: true
       };
       utils._addQueries(ref, queries);
       expect(ref.limitToLast).toHaveBeenCalledWith(10);

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -252,6 +252,46 @@ describe('utils', () => {
       });
     });
 
+    it('should return object with embedded ref if options.withRefs is true', () => {
+      var snapshot = mockFirestoreDocumentSnapshot({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value'
+      });
+      var options = {
+        state: 'prop',
+        withRefs: true
+      };
+      var result = utils._fsPrepareData(snapshot, options);
+      expect(result.hasOwnProperty('prop')).toBe(true);
+      expect(result.prop).toEqual({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value',
+        ref: { _id: 'something' }
+      });
+    });
+
+    it('should return object with embedded id if options.withIds is true', () => {
+      var snapshot = mockFirestoreDocumentSnapshot({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value'
+      });
+      var options = {
+        state: 'prop',
+        withIds: true
+      };
+      var result = utils._fsPrepareData(snapshot, options);
+      expect(result.hasOwnProperty('prop')).toBe(true);
+      expect(result.prop).toEqual({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value',
+        id: '12345'
+      });
+    });
+
     it('should return an object with collection keyed with options.state if isCollection is true', () => {
       var snapshot = mockFirestoreQuerySnapshot([
         mockFirestoreDocumentSnapshot({
@@ -272,7 +312,7 @@ describe('utils', () => {
       });
     });
 
-    it('should return documents with embedded ref if options.withRefs is true', () => {
+    it('should return collection of documents with embedded ref if options.withRefs is true', () => {
       var snapshot = mockFirestoreQuerySnapshot([
         mockFirestoreDocumentSnapshot({
           key1: 'value',
@@ -294,7 +334,7 @@ describe('utils', () => {
       });
     });
 
-    it('should return documents with embedded id if options.withIds is true', () => {
+    it('should return collection of documents with embedded id if options.withIds is true', () => {
       var snapshot = mockFirestoreQuerySnapshot([
         mockFirestoreDocumentSnapshot({
           key1: 'value',

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -8,7 +8,8 @@ const {
   mockCollection,
   mockDoc,
   mockFirestoreDocumentSnapshot,
-  mockFirestoreQuerySnapshot
+  mockFirestoreQuerySnapshot,
+  mockFirestore
 } = require('../helpers');
 
 describe('utils', () => {
@@ -826,6 +827,42 @@ describe('utils', () => {
       const result1 = utils._createHash('endpoint', 'bindToState');
       const result2 = utils._createHash('endpoint', 'bindToState');
       expect(result1).not.toEqual(result2);
+    });
+  });
+
+  describe('_fsCreateRef', () => {
+    it('should create document reference when supplied a document path', () => {
+      const docSpy = jasmine.createSpy();
+      const collectionSpy = jasmine.createSpy();
+      const result = utils._fsCreateRef(
+        'testCollection/testDoc',
+        mockFirestore(docSpy, collectionSpy)
+      );
+      expect(docSpy.calls.count()).toEqual(1);
+      expect(collectionSpy.calls.count()).toEqual(0);
+    });
+
+    it('should create collection reference when supplied a collection path', () => {
+      const docSpy = jasmine.createSpy();
+      const collectionSpy = jasmine.createSpy();
+      const result = utils._fsCreateRef(
+        'testCollection',
+        mockFirestore(docSpy, collectionSpy)
+      );
+      expect(docSpy.calls.count()).toEqual(0);
+      expect(collectionSpy.calls.count()).toEqual(1);
+    });
+
+    it('should return the object if supplied an object', () => {
+      const docSpy = jasmine.createSpy();
+      const collectionSpy = jasmine.createSpy();
+      const result = utils._fsCreateRef(
+        {},
+        mockFirestore(docSpy, collectionSpy)
+      );
+      expect(docSpy.calls.count()).toEqual(0);
+      expect(collectionSpy.calls.count()).toEqual(0);
+      expect(result).toEqual({});
     });
   });
 });

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -4,7 +4,8 @@ const {
   mockRefs,
   mockListeners,
   mockRef,
-  mockSync
+  mockSync,
+  mockCollection
 } = require('../helpers');
 
 describe('utils', () => {
@@ -496,7 +497,6 @@ describe('utils', () => {
 
   describe('_addListener', () => {
     it('should add a listener for a given id', () => {
-      id, invoker, options, ref, listeners;
       var listeners = mockListeners();
       spyOn(listeners, 'set').and.callThrough();
       var id = 1234;
@@ -506,6 +506,22 @@ describe('utils', () => {
       };
       var ref = mockRef();
       utils._addListener(id, invoker, options, ref, listeners);
+      expect(listeners.set.calls.count()).toEqual(1);
+      expect(listeners.size).toEqual(1);
+    });
+  });
+
+  describe('_addFirestoreListener', () => {
+    it('should add a listener for a given id', () => {
+      var listeners = mockListeners();
+      spyOn(listeners, 'set').and.callThrough();
+      var id = 1234;
+      var invoker = 'bindToCollection';
+      var options = {
+        context: {}
+      };
+      var ref = mockCollection();
+      utils._addFirestoreListener(id, invoker, options, ref, listeners);
       expect(listeners.set.calls.count()).toEqual(1);
       expect(listeners.size).toEqual(1);
     });

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -314,7 +314,7 @@ describe('utils', () => {
   });
 
   describe('_addFirestoreQuery', () => {
-    fit('should add valid queries to the ref', () => {
+    it('should add valid queries to the ref', () => {
       var ref = jasmine.createSpyObj([
         'endAt',
         'endBefore',

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -794,4 +794,17 @@ describe('utils', () => {
       expect(listeners.size).toEqual(1);
     });
   });
+
+  describe('_createHash', () => {
+    it('should return a hash of the endpoint, the invoker, and a random number', () => {
+      const result = utils._createHash('endpoint', 'bindToState');
+      expect(result).toEqual(jasmine.any(Number));
+    });
+
+    it('results should be unique', () => {
+      const result1 = utils._createHash('endpoint', 'bindToState');
+      const result2 = utils._createHash('endpoint', 'bindToState');
+      expect(result1).not.toEqual(result2);
+    });
+  });
 });

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -6,7 +6,9 @@ const {
   mockRef,
   mockSync,
   mockCollection,
-  mockDoc
+  mockDoc,
+  mockFirestoreDocumentSnapshot,
+  mockFirestoreQuerySnapshot
 } = require('../helpers');
 
 describe('utils', () => {
@@ -228,6 +230,90 @@ describe('utils', () => {
 
       var result = utils._prepareData(snapshot);
       expect(result).toEqual({ key: 'value' });
+    });
+  });
+
+  describe('_fsPrepareData()', () => {
+    it('should return object keyed with options.state', () => {
+      var snapshot = mockFirestoreDocumentSnapshot({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value'
+      });
+      var options = {
+        state: 'prop'
+      };
+      var result = utils._fsPrepareData(snapshot, options);
+      expect(result.hasOwnProperty('prop')).toBe(true);
+      expect(result.prop).toEqual({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value'
+      });
+    });
+
+    it('should return an object with collection keyed with options.state if isCollection is true', () => {
+      var snapshot = mockFirestoreQuerySnapshot([
+        mockFirestoreDocumentSnapshot({
+          key1: 'value',
+          key2: 'value',
+          key3: 'value'
+        })
+      ]);
+      var options = {
+        state: 'prop'
+      };
+      var result = utils._fsPrepareData(snapshot, options, true);
+      expect(result.prop.length).toEqual(1);
+      expect(result.prop[0]).toEqual({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value'
+      });
+    });
+
+    it('should return documents with embedded ref if options.withRefs is true', () => {
+      var snapshot = mockFirestoreQuerySnapshot([
+        mockFirestoreDocumentSnapshot({
+          key1: 'value',
+          key2: 'value',
+          key3: 'value'
+        })
+      ]);
+      var options = {
+        state: 'prop',
+        withRefs: true
+      };
+      var result = utils._fsPrepareData(snapshot, options, true);
+      expect(result.prop.length).toEqual(1);
+      expect(result.prop[0]).toEqual({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value',
+        ref: { _id: 'something' }
+      });
+    });
+
+    it('should return documents with embedded id if options.withIds is true', () => {
+      var snapshot = mockFirestoreQuerySnapshot([
+        mockFirestoreDocumentSnapshot({
+          key1: 'value',
+          key2: 'value',
+          key3: 'value'
+        })
+      ]);
+      var options = {
+        state: 'prop',
+        withIds: true
+      };
+      var result = utils._fsPrepareData(snapshot, options, true);
+      expect(result.prop.length).toEqual(1);
+      expect(result.prop[0]).toEqual({
+        key1: 'value',
+        key2: 'value',
+        key3: 'value',
+        id: '12345'
+      });
     });
   });
 

--- a/tests/specs/utils.spec.js
+++ b/tests/specs/utils.spec.js
@@ -313,6 +313,45 @@ describe('utils', () => {
     });
   });
 
+  describe('_addFirestoreQuery', () => {
+    fit('should add valid queries to the ref', () => {
+      var ref = jasmine.createSpyObj([
+        'endAt',
+        'endBefore',
+        'limit',
+        'orderBy',
+        'startAt',
+        'startAfter',
+        'where'
+      ]);
+      ref.endAt.and.returnValue(ref);
+      ref.endBefore.and.returnValue(ref);
+      ref.limit.and.returnValue(ref);
+      ref.orderBy.and.returnValue(ref);
+      ref.startAt.and.returnValue(ref);
+      ref.where.and.returnValue(ref);
+      ref.startAfter.and.returnValue(ref);
+      const query = ref => {
+        return ref
+          .endAt({})
+          .startAt({})
+          .where('key', '==', 'value')
+          .limit(5)
+          .orderBy('key')
+          .endBefore({})
+          .startAfter({});
+      };
+      utils._addFirestoreQuery(ref, query);
+      expect(ref.endAt).toHaveBeenCalledWith({});
+      expect(ref.startAt).toHaveBeenCalledWith({});
+      expect(ref.endBefore).toHaveBeenCalledWith({});
+      expect(ref.startAfter).toHaveBeenCalledWith({});
+      expect(ref.where).toHaveBeenCalledWith('key', '==', 'value');
+      expect(ref.orderBy).toHaveBeenCalledWith('key');
+      expect(ref.limit).toHaveBeenCalledWith(5);
+    });
+  });
+
   describe('_firebaseRefsMixin', () => {
     it('should add ref to refs', () => {
       var refs = mockRefs();

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -252,6 +252,16 @@ describe('Validators', () => {
   });
 
   describe('_validateDocumentPath', () => {
+    it('should not throw if argument is not a string', () => {
+      expect(() => {
+        _validateDocumentPath();
+      }).toThrow();
+    });
+    it('should throw if path does not have an even number of segments', () => {
+      expect(() => {
+        _validateDocumentPath('collectionName');
+      }).toThrow();
+    });
     it('should throw if path does not have an even number of segments', () => {
       expect(() => {
         _validateDocumentPath('collectionName');
@@ -270,6 +280,11 @@ describe('Validators', () => {
   });
 
   describe('_validateCollectionPath', () => {
+    it('should not throw if argument is not a string', () => {
+      expect(() => {
+        _validateCollectionPath();
+      }).toThrow();
+    });
     it('should throw if path does not have an odd number of segments', () => {
       expect(() => {
         _validateCollectionPath('collectionName/document');

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -1,4 +1,4 @@
-fdescribe('Validators', () => {
+describe('Validators', () => {
   const {
     optionValidators,
     _validateEndpoint,

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -262,6 +262,11 @@ describe('Validators', () => {
         _validateDocumentPath('collectionName/document');
       }).not.toThrow();
     });
+    it('should not throw if argument is valid', () => {
+      expect(() => {
+        _validateDocumentPath('/collectionName/document');
+      }).not.toThrow();
+    });
   });
 
   describe('_validateCollectionPath', () => {

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -203,7 +203,7 @@ describe('Validators', () => {
   describe('_validateEndpoint()', () => {
     it('should throw if endpoint is not a string', () => {
       expect(() => {
-        _validateEndpoint({});
+        _validateEndpoint(null);
       }).toThrow();
     });
     it('should throw if endpoint is empty string', () => {

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -238,9 +238,15 @@ describe('Validators', () => {
       }).toThrow();
     });
 
-    it('should not throw if argument is valid', () => {
+    it('should not throw if argument is valid RTDB object', () => {
       expect(() => {
         _validateDatabase({ ref: () => {} });
+      }).not.toThrow();
+    });
+
+    it('should not throw if argument is valid Firestore DB object', () => {
+      expect(() => {
+        _validateDatabase({ collection: () => {} });
       }).not.toThrow();
     });
   });

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -1,10 +1,13 @@
-fdescribe('Validators', () => {
-  var optionValidators = require('../../src/lib/validators').optionValidators;
-  var _validateEndpoint = require('../../src/lib/validators')._validateEndpoint;
-  var _validateDatabase = require('../../src/lib/validators')._validateDatabase;
-  var _validateDocumentPath = require('../../src/lib/validators')
-    ._validateDocumentPath;
-  var invalidEndpoints = require('../fixtures/invalidEndpoints');
+describe('Validators', () => {
+  const {
+    optionValidators,
+    _validateEndpoint,
+    _validateDatabase,
+    _validateCollectionPath,
+    _validateDocumentPath
+  } = require('../../src/lib/validators');
+  const invalidEndpoints = require('../fixtures/invalidEndpoints');
+
   describe('optionValidators', () => {
     describe('notObject()', () => {
       it('should throw on non object', () => {
@@ -251,6 +254,24 @@ fdescribe('Validators', () => {
     it('should not throw if argument is valid', () => {
       expect(() => {
         _validateDocumentPath('collectionName/document');
+      }).not.toThrow();
+    });
+  });
+
+  describe('_validateCollectionPath', () => {
+    it('should throw if path does not have an odd number of segments', () => {
+      expect(() => {
+        _validateCollectionPath('collectionName/document');
+      }).toThrow();
+    });
+    it('should not throw if argument is valid', () => {
+      expect(() => {
+        _validateCollectionPath('collectionName');
+      }).not.toThrow();
+    });
+    it('should not throw if argument is valid', () => {
+      expect(() => {
+        _validateCollectionPath('collectionName/document/subCollection');
       }).not.toThrow();
     });
   });

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -262,7 +262,7 @@ describe('Validators', () => {
         _validateDocumentPath('collectionName/document');
       }).not.toThrow();
     });
-    it('should not throw if argument is valid', () => {
+    it('should not throw if argument is valid with leading slash', () => {
       expect(() => {
         _validateDocumentPath('/collectionName/document');
       }).not.toThrow();
@@ -283,6 +283,11 @@ describe('Validators', () => {
     it('should not throw if argument is valid', () => {
       expect(() => {
         _validateCollectionPath('collectionName/document/subCollection');
+      }).not.toThrow();
+    });
+    it('should not throw if argument is valid with leading slash', () => {
+      expect(() => {
+        _validateCollectionPath('/collectionName/document/subCollection');
       }).not.toThrow();
     });
   });

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -1,14 +1,10 @@
-describe('Validators', () => {
-  var optionValidators;
-  var _validateEndpoint;
-  var _validateDatabase;
-  var invalidEndpoints;
-  beforeAll(() => {
-    optionValidators = require('../../src/lib/validators').optionValidators;
-    _validateEndpoint = require('../../src/lib/validators')._validateEndpoint;
-    _validateDatabase = require('../../src/lib/validators')._validateDatabase;
-    invalidEndpoints = require('../fixtures/invalidEndpoints');
-  });
+fdescribe('Validators', () => {
+  var optionValidators = require('../../src/lib/validators').optionValidators;
+  var _validateEndpoint = require('../../src/lib/validators')._validateEndpoint;
+  var _validateDatabase = require('../../src/lib/validators')._validateDatabase;
+  var _validateDocumentPath = require('../../src/lib/validators')
+    ._validateDocumentPath;
+  var invalidEndpoints = require('../fixtures/invalidEndpoints');
   describe('optionValidators', () => {
     describe('notObject()', () => {
       it('should throw on non object', () => {
@@ -242,6 +238,19 @@ describe('Validators', () => {
     it('should not throw if argument is valid', () => {
       expect(() => {
         _validateDatabase({ ref: () => {} });
+      }).not.toThrow();
+    });
+  });
+
+  describe('_validateDocumentPath', () => {
+    it('should throw if path does not have an even number of segments', () => {
+      expect(() => {
+        _validateDocumentPath('collectionName');
+      }).toThrow();
+    });
+    it('should not throw if argument is valid', () => {
+      expect(() => {
+        _validateDocumentPath('collectionName/document');
       }).not.toThrow();
     });
   });

--- a/tests/specs/validators.spec.js
+++ b/tests/specs/validators.spec.js
@@ -1,4 +1,4 @@
-describe('Validators', () => {
+fdescribe('Validators', () => {
   const {
     optionValidators,
     _validateEndpoint,
@@ -7,6 +7,11 @@ describe('Validators', () => {
     _validateDocumentPath
   } = require('../../src/lib/validators');
   const invalidEndpoints = require('../fixtures/invalidEndpoints');
+  const firebaseConfig = require('../fixtures/config');
+
+  //firebase and firestore should be globally available
+  const firebase = require('firebase');
+  require('firebase/firestore');
 
   describe('optionValidators', () => {
     describe('notObject()', () => {
@@ -224,6 +229,25 @@ describe('Validators', () => {
         }).toThrow();
       });
     });
+    it('should not throw if endpoint is a document reference', done => {
+      expect(() => {
+        const app = firebase.initializeApp(firebaseConfig);
+        const docRef = app
+          .firestore()
+          .collection('testCollection')
+          .doc('testDoc');
+        _validateEndpoint(docRef);
+        app.delete().then(done);
+      }).not.toThrow();
+    });
+    it('should not throw if endpoint is a collection reference', done => {
+      expect(() => {
+        const app = firebase.initializeApp(firebaseConfig);
+        const collectionRef = app.firestore().collection('testCollection');
+        _validateEndpoint(collectionRef);
+        app.delete().then(done);
+      }).not.toThrow();
+    });
   });
 
   describe('_validateDatabase()', () => {
@@ -252,7 +276,7 @@ describe('Validators', () => {
   });
 
   describe('_validateDocumentPath', () => {
-    it('should not throw if argument is not a string', () => {
+    it('should throw if argument is undefined', () => {
       expect(() => {
         _validateDocumentPath();
       }).toThrow();
@@ -277,10 +301,18 @@ describe('Validators', () => {
         _validateDocumentPath('/collectionName/document');
       }).not.toThrow();
     });
+    it('should not throw if argument a document reference', done => {
+      expect(() => {
+        const app = firebase.initializeApp(firebaseConfig);
+        const docRef = firebase.firestore().doc('testCollection/testDoc');
+        _validateDocumentPath(docRef);
+        app.delete().then(done);
+      }).not.toThrow();
+    });
   });
 
   describe('_validateCollectionPath', () => {
-    it('should not throw if argument is not a string', () => {
+    it('should throw if argument is undefined', () => {
       expect(() => {
         _validateCollectionPath();
       }).toThrow();
@@ -303,6 +335,14 @@ describe('Validators', () => {
     it('should not throw if argument is valid with leading slash', () => {
       expect(() => {
         _validateCollectionPath('/collectionName/document/subCollection');
+      }).not.toThrow();
+    });
+    it('should not throw if argument a collection reference', done => {
+      expect(() => {
+        const app = firebase.initializeApp(firebaseConfig);
+        const collectionRef = firebase.firestore().collection('testCollection');
+        _validateCollectionPath(collectionRef);
+        app.delete().then(done);
       }).not.toThrow();
     });
   });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,14 +16,22 @@ var externals = {
     }
   },
   firebase: {
-    'firebase': {
+    firebase: {
       root: 'firebase',
       commonjs2: 'firebase',
       commonjs: 'firebase',
       amd: 'firebase'
     }
+  },
+  firestore: {
+    'firebase/firestore': {
+      root: 'firebase/firestore',
+      commonjs2: 'firebase/firestore',
+      commonjs: 'firebase/firestore',
+      amd: 'firebase/firestore'
+    }
   }
-}
+};
 
 var loaders = [
   {
@@ -36,16 +44,16 @@ var loaders = [
   }
 ];
 
-module.exports = [{
-  entry: ['./src/rebase.js'],
-  output: {
-    filename: "dist/bundle.js",
-    libraryTarget: 'umd'
-  },
-  externals: [
-    externals.app, externals.database, externals.firebase
-  ],
-  module: {
-    loaders: loaders
+module.exports = [
+  {
+    entry: ['./src/rebase.js'],
+    output: {
+      filename: 'dist/bundle.js',
+      libraryTarget: 'umd'
+    },
+    externals: [externals.app, externals.database, externals.firebase],
+    module: {
+      loaders: loaders
+    }
   }
-}];
+];


### PR DESCRIPTION
resolves #233. 

Adds support for using re-base with firestore. Adds the following methods:
`syncDoc`
`bindDoc`
`bindCollection`
`listenToDoc`
`listenToCollection`
`addToCollection`
`updateDoc`
`removeDoc`
`removeFromCollection`


